### PR TITLE
changing options height for correct displaying list

### DIFF
--- a/src/lib/components/ui/MultiSelect.svelte
+++ b/src/lib/components/ui/MultiSelect.svelte
@@ -244,7 +244,7 @@
     list-style: none;
     margin-block-end: 0;
     margin-block-start: 0;
-    max-height: 70vh;
+    max-height: 53vh;
     overflow: auto;
     padding-inline-start: 0;
     position: absolute;


### PR DESCRIPTION
#### Relevant Issue
This is the correct change fixing the option list height:
![image](https://user-images.githubusercontent.com/43384963/132895451-ae3728a4-e808-4daf-801c-f5d311fad7e5.png)
The list covered the save and cancel buttons
#### Summarize what changed in this PR (for developers)
N/A
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/132895574-dd5d0755-e37b-4e7e-9c31-79c7146a810e.png)
The list has a better height. I tested in many screen widths and Chrome tool devices screens and it works with each of them
I changed options class height from 70vh to 53vh.
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
N/A
