### PR TITLE
differentiating contact us icon from FAQ icon in the Header component

### DIFF
--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -4,11 +4,7 @@
   import ShowHide from '$svelteui/functions/ShowHide.svelte';
   import Button from '$svelteui/ui/Button.svelte';
   import { firebaseConfig } from '$sveltefire/config';
-  let screenWidth: number;
-  const mobileView = 639;
 </script>
-
-<svelte:window bind:innerWidth={screenWidth} />
 
 <header>
   {#if $$slots.default}
@@ -64,11 +60,8 @@
 
   <ShowHide let:show let:toggle>
     <Button form="text" class="print:hidden" onclick={toggle}>
-      {#if screenWidth > mobileView}
-        <i class="far fa-comment" />
-      {:else}
-        <i class="far fa-question-circle" />
-      {/if}
+      <i class="hidden sm:inline far fa-comment" />
+      <i class="sm:hidden far fa-question-circle" />
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>

--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -60,8 +60,8 @@
 
   <ShowHide let:show let:toggle>
     <Button form="text" class="print:hidden" onclick={toggle}>
-      <i class="hidden sm:inline far fa-comment" />
-      <i class="sm:hidden far fa-question-circle" />
+      <i class="hidden lg:inline far fa-comment" />
+      <i class="lg:hidden far fa-question-circle" />
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>

--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -60,7 +60,7 @@
 
   <ShowHide let:show let:toggle>
     <Button form="text" class="print:hidden" onclick={toggle}>
-      <i class="far fa-question-circle" />
+      <i class="far fa-comment" />
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>

--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -4,7 +4,11 @@
   import ShowHide from '$svelteui/functions/ShowHide.svelte';
   import Button from '$svelteui/ui/Button.svelte';
   import { firebaseConfig } from '$sveltefire/config';
+  let screenWidth: number;
+  const mobileView = 639;
 </script>
+
+<svelte:window bind:innerWidth={screenWidth} />
 
 <header>
   {#if $$slots.default}
@@ -60,7 +64,11 @@
 
   <ShowHide let:show let:toggle>
     <Button form="text" class="print:hidden" onclick={toggle}>
-      <i class="far fa-comment" />
+      {#if screenWidth > mobileView}
+        <i class="far fa-comment" />
+      {:else}
+        <i class="far fa-question-circle" />
+      {/if}
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>


### PR DESCRIPTION
#### Relevant Issue
Differentiating contact us icon from FAQ icon in the Header component only in desktop screens

#### Summarize what changed in this PR (for developers)
Adding `<i class="hidden lg:inline far fa-comment" />` as sibling of `<i class="lg:hidden far fa-question-circle" />`

#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/133141993-ad3f1b12-a0aa-458a-8acb-86f74f45a748.png)
FAQ & Contact us are not the same anymore
When the witdth of the screen is large it shows us comment mark icon. If it's smaller it shows us question mark icon.
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-lx64jbsca-livingtongues.vercel.app/
Please, resize the screen in order to check the icon change