### PR TITLE
Fixing duplicate contact us icons on prod

### DIFF
--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -59,9 +59,14 @@
   </Button>
 
   <ShowHide let:show let:toggle>
-    <Button form="text" class="print:hidden" onclick={toggle}>
-      <i class="hidden lg:inline far fa-comment" />
-      <i class="lg:hidden far fa-question-circle" />
+    <Button form="text" class="hidden lg:inline print:hidden" onclick={toggle}>
+      <i class="far fa-comment" />
+      <span class="ml-1 hidden sm:inline">
+        {$_('header.contact_us', { default: 'Contact Us' })}
+      </span>
+    </Button>
+    <Button form="text" class="lg:hidden print:hidden" onclick={toggle}>
+      <i class="far fa-question-circle" />
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>

--- a/src/lib/components/shell/Header.svelte
+++ b/src/lib/components/shell/Header.svelte
@@ -59,14 +59,13 @@
   </Button>
 
   <ShowHide let:show let:toggle>
-    <Button form="text" class="hidden lg:inline print:hidden" onclick={toggle}>
-      <i class="far fa-comment" />
-      <span class="ml-1 hidden sm:inline">
-        {$_('header.contact_us', { default: 'Contact Us' })}
+    <Button form="text" class="print:hidden" onclick={toggle}>
+      <span class="hidden lg:inline">
+        <i class="far fa-comment" />
       </span>
-    </Button>
-    <Button form="text" class="lg:hidden print:hidden" onclick={toggle}>
-      <i class="far fa-question-circle" />
+      <span class="lg:hidden">
+        <i class="far fa-question-circle" />
+      </span>
       <span class="ml-1 hidden sm:inline">
         {$_('header.contact_us', { default: 'Contact Us' })}
       </span>


### PR DESCRIPTION
#### Relevant Issue
Fixes #23 
#### Summarize what changed in this PR (for developers)
Refactoring: creating new span tags in order to wrap around the icon elements instead of button duplication.

#### Summarize changes in this PR (for public-facing changelog)
N/A

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-cun34vcr1-livingtongues.vercel.app/