### PR TITLE
adding gender to speakers on Firestore DB

### DIFF
--- a/src/lib/components/audio/AddSpeaker.svelte
+++ b/src/lib/components/audio/AddSpeaker.svelte
@@ -6,7 +6,6 @@
   import Button from '$svelteui/ui/Button.svelte';
   import { add } from '$sveltefire/firestore';
   import type { ISpeaker } from '$lib/interfaces';
-  import type { Gender } from '$lib/interfaces/speaker.interface';
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch('close');
@@ -14,7 +13,7 @@
   let displayName = '';
   let birthplace = '';
   let decade = 4;
-  let gender = 'm';
+  let gender: ISpeaker['gender'] = 'm';
   let agreeToBeOnline = true;
 
   async function addSpeaker() {
@@ -22,7 +21,7 @@
       displayName: displayName.trim(),
       birthplace: birthplace.trim(),
       decade,
-      gender: gender as Gender,
+      gender,
       contributingTo: [$dictionary.id],
     };
 

--- a/src/lib/interfaces/speaker.interface.ts
+++ b/src/lib/interfaces/speaker.interface.ts
@@ -4,10 +4,8 @@ export interface ISpeaker extends IFirestoreMetaData {
   displayName: string;
   uid?: string; // matches uid of signed-up user if they also have an account
   decade?: number; // used to be a string - refactor in database
-  gender?: Gender;
+  gender?: 'm' | 'f' | 'o';
   birthplace?: string;
   contributingTo?: string[]; // array of dictionaryIDs
   photoURL?: string;
 }
-
-export type Gender = 'm' | 'f' | 'o';


### PR DESCRIPTION
#### Relevant Issue
N/A

#### Summarize what changed in this PR (for developers)
I'm exporting a new Gender type from the speakers.interface.ts, importing this type on the AddSpeaker component and adding to the request as a Gender type (only when adding a new speaker, not when editing).
#### Summarize changes in this PR (for public-facing changelog)
DB is storing gender of speakers when adding one of them.
![image](https://user-images.githubusercontent.com/43384963/138180906-5dadcf4b-e281-48e1-bc68-9fccc1f1ba8b.png)
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
Add a new speaker and filter & check on https://console.firebase.google.com/project/talking-dictionaries-dev/firestore/data/~2Fspeakers~2FvfO5Sdzg6EsNWgBExLVQ
