### PR TITLE
solve error when about or grammar is undefined

### DIFF
--- a/src/routes/[dictionaryId]/about.svelte
+++ b/src/routes/[dictionaryId]/about.svelte
@@ -6,7 +6,9 @@
     const dictionaryId = params.dictionaryId;
     try {
       const aboutDoc = await fetchDoc<IAbout>(`dictionaries/${dictionaryId}/info/about`);
-      return { props: { aboutDoc, dictionaryId } };
+      if (aboutDoc && aboutDoc.about) {
+        return { props: { about: aboutDoc.about, dictionaryId } };
+      } else return { props: { about: null, dictionaryId } };
     } catch (err) {
       return { props: { aboutDoc: null, dictionaryId } };
     }
@@ -17,7 +19,7 @@
   import { _ } from 'svelte-i18n';
   import { dictionary, isManager } from '$lib/stores';
 
-  export let aboutDoc: IAbout = { about: '' },
+  export let about = '',
     dictionaryId: string;
   import Button from '$svelteui/ui/Button.svelte';
   import { set } from '$sveltefire/firestore';
@@ -25,7 +27,7 @@
 
   async function save() {
     try {
-      await set(`dictionaries/${dictionaryId}/info/about`, aboutDoc);
+      await set<IAbout>(`dictionaries/${dictionaryId}/info/about`, { about });
       window.location.replace(`/${dictionaryId}/about`);
     } catch (err) {
       alert(err);
@@ -63,13 +65,13 @@
     {#if editing}
       <div class="max-w-screen-md prose prose-lg">
         {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
-          <ClassicCustomized bind:html={aboutDoc.about} />
+          <ClassicCustomized bind:html={about} />
         {/await}
       </div>
     {/if}
     <div class="prose prose-lg max-w-screen-md {editing && 'hidden md:block mt-14 ml-3'}">
-      {#if aboutDoc && aboutDoc.about}
-        {@html aboutDoc.about}
+      {#if about}
+        {@html about}
       {:else}
         <i>{$_('dictionary.no_info_yet', { default: 'No information yet' })}</i>
       {/if}

--- a/src/routes/[dictionaryId]/grammar.svelte
+++ b/src/routes/[dictionaryId]/grammar.svelte
@@ -78,7 +78,6 @@
     </div>
   </div>
 </div>
-<pre>{grammar}</pre>
 
 <style>
   :global(.grammar img) {

--- a/src/routes/[dictionaryId]/grammar.svelte
+++ b/src/routes/[dictionaryId]/grammar.svelte
@@ -7,9 +7,11 @@
     const dictionaryId = params.dictionaryId;
     try {
       const grammarDoc = await fetchDoc<IGrammar>(`dictionaries/${dictionaryId}/info/grammar`);
-      return { props: { grammarDoc, dictionaryId } };
+      if (grammarDoc && grammarDoc.grammar) {
+        return { props: { grammar: grammarDoc.grammar, dictionaryId } };
+      } else return { props: { grammar: null, dictionaryId } };
     } catch (err) {
-      return { props: { grammarDoc: null, dictionaryId } };
+      return { props: { grammar: null, dictionaryId } };
     }
   };
 </script>
@@ -18,14 +20,14 @@
   import { _ } from 'svelte-i18n';
   import { dictionary, isManager } from '$lib/stores';
 
-  export let grammarDoc: IGrammar = { grammar: '' },
+  export let grammar = '',
     dictionaryId: string;
   import Button from '$svelteui/ui/Button.svelte';
   import { set } from '$sveltefire/firestore';
 
   async function save() {
     try {
-      await set(`dictionaries/${dictionaryId}/info/grammar`, grammarDoc);
+      await set<IGrammar>(`dictionaries/${dictionaryId}/info/grammar`, { grammar });
       window.location.replace(`/${dictionaryId}/grammar`);
     } catch (err) {
       alert(err);
@@ -63,19 +65,20 @@
     {#if editing}
       <div class="max-w-screen-md prose prose-lg">
         {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
-          <ClassicCustomized bind:html={grammarDoc.grammar} />
+          <ClassicCustomized bind:html={grammar} />
         {/await}
       </div>
     {/if}
     <div class="prose prose-lg max-w-screen-md {editing && 'hidden md:block mt-14 ml-3'}">
-      {#if grammarDoc && grammarDoc.grammar}
-        {@html grammarDoc.grammar}
+      {#if grammar}
+        {@html grammar}
       {:else}
         <i>{$_('dictionary.no_info_yet', { default: 'No information yet' })}</i>
       {/if}
     </div>
   </div>
 </div>
+<pre>{grammar}</pre>
 
 <style>
   :global(.grammar img) {


### PR DESCRIPTION
#### Summarize what changed in this PR (for developers)
Adjusted about and grammar pages to not use properties of an object that could error when undefined. Now the property is just a string.

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
Use the preview url below and try editing the about and grammar pages of one of your own dictionaries that has never had them touched (so they would be undefined) and make sure you can add info and save successfully.