### PR TITLE
converting string sources in arrays

### DIFF
--- a/src/routes/[dictionaryId]/export/_entries.ts
+++ b/src/routes/[dictionaryId]/export/_entries.ts
@@ -54,8 +54,10 @@ async function zipper(
 function valuesInColumn(itemsFormatted, i, values, columnName, fn) {
   if (values) {
     let stringValue = '';
-    //In case some strings contain commas
+    //There are some dictionaries that have strings as sources instead of arrays
+    values = typeof values === 'string' ? [values] : values;
     const list = values.map(fn);
+    //In case some strings contain commas
     stringValue += list.map((el) => el.replace(/,/g, ' -'));
     stringValue = stringValue.replace(/,/g, ' | ');
     Object.assign(itemsFormatted[i], JSON.parse(`{"${columnName}": "${stringValue}"}`));


### PR DESCRIPTION
#### Relevant Issue
#65 
#### Summarize what changed in this PR (for developers)
For some reason some dictionaries have sources stored as strings and not as arrays. I'm converting every source in arrays when needed
#### Summarize changes in this PR (for public-facing changelog)
Now you can download those dictionaries too
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-8imaygvue-livingtongues.vercel.app/kalanga/export
