### PR TITLE
allow users to login when using Assamese interface

### DIFF
--- a/src/lib/components/shell/AuthModal.svelte
+++ b/src/lib/components/shell/AuthModal.svelte
@@ -7,6 +7,7 @@
   // https://github.com/firebase/firebaseui-web/blob/master/LANGUAGES.md
   if (localizedAbbrev === 'he') localizedAbbrev = 'iw';
   if (localizedAbbrev === 'ms') localizedAbbrev = 'en'; // Malay is not yet available
+  if (localizedAbbrev === 'as') localizedAbbrev = 'en'; // Assamese is not yet available
 
   import Modal from '$lib/components/ui/Modal.svelte';
   export let context: 'force' = undefined;


### PR DESCRIPTION
#### Relevant Issue
N/A
#### Summarize what changed in this PR (for developers)
Add Assamese manually in AuthModal component
#### Summarize changes in this PR (for public-facing changelog)
N/A
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
Try to login using Assamese interface on https://living-dictionaries-9fp0tkd1f-livingtongues.vercel.app/

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/86"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

