### PR TITLE
new gallery view

### DIFF
--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -5,22 +5,33 @@
   export let canEdit = false;
 </script>
 
-<div
-  class="bg-gray-300 shadow relative rounded overflow-hidden"
-  style="max-width: 500px; max-height: 500px;">
-  <Image square={480} {entry} {canEdit} />
-  <div
-    class="text-dark-shadow text-white font-semibold p-2 absolute top-0
-            left-0">
-    {@html entry._highlightResult ? entry._highlightResult.lx.value : entry.lx}
-  </div>
-  <div
-    class="text-dark-shadow text-white p-2 absolute bottom-0 left-0
-            text-xs">
-    {@html entry._highlightResult
-      ? entry._highlightResult.gl.en.value
-      : entry.gl && entry.gl.en
-      ? entry.gl.en
-      : ''}
+<div class="flex flex-col relative rounded" style="max-width: 500px; max-height: 500px;">
+  <div class="bg-gray-300 shadow">
+    <div class="aspect-square overflow-hidden">
+      <Image square={480} {entry} {canEdit} />
+    </div>
+    <div class="card-content-wrapper">
+      <p class="font-semibold absolute top-0 left-0">
+        {@html entry._highlightResult ? entry._highlightResult.lx.value : entry.lx}
+      </p>
+      <p class="absolute bottom-0 left-0 text-xs">
+        {@html entry._highlightResult
+          ? entry._highlightResult.gl.en.value
+          : entry.gl && entry.gl.en
+          ? entry.gl.en
+          : ''}
+      </p>
+    </div>
   </div>
 </div>
+
+<style>
+  .card-content-wrapper {
+    background: #f3f3f3;
+    padding: 20px 20px 20px 10px;
+  }
+
+  .card-content-wrapper > p {
+    position: relative;
+  }
+</style>

--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -28,7 +28,7 @@
 <style>
   .card-content-wrapper {
     background: #f3f3f3;
-    padding: 20px 20px 20px 10px;
+    padding: 10px;
   }
 
   .card-content-wrapper > p {


### PR DESCRIPTION
#### Relevant Issue
Suggested changes in the gallery view
#### Summarize what changed in this PR (for developers)
_GalleryEntry component modified
#### Summarize changes in this PR (for public-facing changelog)
I changed the style of the cards on the gallery:
![image](https://user-images.githubusercontent.com/43384963/151238682-8805a9e9-e75e-437b-bb30-93ab6331e486.png)
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-7hvd80113-livingtongues.vercel.app/gta/entries/gallery?entries_prod%5Btoggle%5D%5BhasImage%5D=true

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/90"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

