### PR TITLE
fix changed names in export components

### DIFF
--- a/src/routes/[dictionaryId]/export.svelte
+++ b/src/routes/[dictionaryId]/export.svelte
@@ -24,8 +24,8 @@
     const entries = await getCollection<IEntry>(`dictionaries/${$dictionary.id}/words`);
     const speakers = await fetchSpeakers(entries);
     formattedEntries = await formatEntriesForCSV(entries, $dictionary, speakers);
-    entriesWithImages = formattedEntries.filter((entry) => entry.impa);
-    entriesWithAudio = formattedEntries.filter((entry) => entry.aupa);
+    entriesWithImages = formattedEntries.filter((entry) => entry.pfpa);
+    entriesWithAudio = formattedEntries.filter((entry) => entry.sfpa);
     mounted = true;
   });
 </script>
@@ -118,8 +118,8 @@
     onclick={() => {
       const finalizedEntries = formattedEntries.map((entry) => {
         const newEntry = { ...entry };
-        delete newEntry.impa;
-        delete newEntry.aupa;
+        delete newEntry.pfpa;
+        delete newEntry.sfpa;
         return newEntry;
       });
       downloadObjArrAsCSV(finalizedEntries, $dictionary.name);

--- a/src/routes/[dictionaryId]/export/_DownloadMedia.svelte
+++ b/src/routes/[dictionaryId]/export/_DownloadMedia.svelte
@@ -23,44 +23,44 @@
     for (const entry of entriesWithImages) {
       if (destroyed) return;
       try {
-        const response = await fetch(getStorageDownloadUrl(entry.impa));
+        const response = await fetch(getStorageDownloadUrl(entry.pfpa));
         if (response.ok) {
           const blob = await response.blob();
-          zip.folder(`${dictionary.id}_Images/`).file(entry.imFriendlyName, blob, { binary: true });
+          zip.folder(`${dictionary.id}_Images/`).file(entry.pfFriendlyName, blob, { binary: true });
         } else {
           errors = [
             ...errors,
-            `Entry: ${entry.lx}, Id: ${entry.id}, File: ${entry.impa}, Error: ${response.statusText}`,
+            `Entry: ${entry.lx}, Id: ${entry.id}, File: ${entry.pfpa}, Error: ${response.statusText}`,
           ];
         }
       } catch (e) {
-        errors = [...errors, `Entry: ${entry.id}, File: ${entry.impa}, ${e}`];
+        errors = [...errors, `Entry: ${entry.id}, File: ${entry.pfpa}, ${e}`];
       }
       fetched++;
     }
     for (const entry of entriesWithAudio) {
       if (destroyed) return;
       try {
-        const response = await fetch(getStorageDownloadUrl(entry.aupa));
+        const response = await fetch(getStorageDownloadUrl(entry.sfpa));
         if (response.ok) {
           const blob = await response.blob();
-          zip.folder(`${dictionary.id}_Audio/`).file(entry.auFriendlyName, blob, { binary: true });
+          zip.folder(`${dictionary.id}_Audio/`).file(entry.sfFriendlyName, blob, { binary: true });
         } else {
           errors = [
             ...errors,
-            `Entry: ${entry.lx}, Id: ${entry.id}, File: ${entry.aupa}, Error: ${response.status} ${response.statusText}`,
+            `Entry: ${entry.lx}, Id: ${entry.id}, File: ${entry.sfpa}, Error: ${response.status} ${response.statusText}`,
           ];
         }
       } catch (e) {
-        errors = [...errors, `Entry: ${entry.id}, File: ${entry.aupa}, ${e}`];
+        errors = [...errors, `Entry: ${entry.id}, File: ${entry.sfpa}, ${e}`];
       }
       fetched++;
     }
 
     const finalizedEntries = formattedEntries.map((entry) => {
       const newEntry = { ...entry };
-      delete newEntry.impa;
-      delete newEntry.aupa;
+      delete newEntry.pfpa;
+      delete newEntry.sfpa;
       return newEntry;
     });
     const CSVBlob = fileAsBlob(finalizedEntries);

--- a/src/routes/[dictionaryId]/export/_formatEntries.ts
+++ b/src/routes/[dictionaryId]/export/_formatEntries.ts
@@ -192,6 +192,7 @@ export function formatEntriesForCSV(
       });
     }
     if (entry.pf && entry.pf.path) {
+      itemsFormatted[i]['pfpa'] = entry.pf.path;
       itemsFormatted[i]['pfFriendlyName'] = friendlyName(entry, entry.pf.path);
     } else {
       itemsFormatted[i]['pfFriendlyName'] = '';


### PR DESCRIPTION
#### Relevant Issue
#67 
#### Summarize what changed in this PR (for developers)
Creation of format entries tests, no more using JSON.parse and Object.assign when it makes code more verbose for no benefit, using already established naming conventions... **But with the changed names fixed in each component**
#### Summarize changes in this PR (for public-facing changelog)
N/A
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
