### PR TITLE
avoid to show duplicates dictionaries when using the search dictionaries input

### DIFF
--- a/src/lib/components/home/Search.svelte
+++ b/src/lib/components/home/Search.svelte
@@ -39,8 +39,9 @@
         });
       })
       .reduce((acc, dictionary) => {
-        return acc[0]?.id === dictionary.id ? [...acc] : [...acc, dictionary];
+        return acc.find((e) => e.id === dictionary.id) ? [...acc] : [...acc, dictionary];
       }, []);
+    console.log('fd:', filteredDictionaries);
   }
 
   let searchBlurTimeout;

--- a/src/lib/components/home/Search.svelte
+++ b/src/lib/components/home/Search.svelte
@@ -29,14 +29,18 @@
 
   let filteredDictionaries: IDictionary[] = [];
   $: {
-    filteredDictionaries = dictionaries.filter((dictionary) => {
-      return Object.keys(dictionary).some((k) => {
-        return (
-          typeof dictionary[k] === 'string' &&
-          dictionary[k].toLowerCase().includes(searchString.toLowerCase())
-        );
-      });
-    });
+    filteredDictionaries = dictionaries
+      .filter((dictionary) => {
+        return Object.keys(dictionary).some((k) => {
+          return (
+            typeof dictionary[k] === 'string' &&
+            dictionary[k].toLowerCase().includes(searchString.toLowerCase())
+          );
+        });
+      })
+      .reduce((acc, dictionary) => {
+        return acc[0]?.id === dictionary.id ? [...acc] : [...acc, dictionary];
+      }, []);
   }
 
   let searchBlurTimeout;

--- a/src/lib/components/home/Search.svelte
+++ b/src/lib/components/home/Search.svelte
@@ -41,7 +41,6 @@
       .reduce((acc, dictionary) => {
         return acc.find((e) => e.id === dictionary.id) ? [...acc] : [...acc, dictionary];
       }, []);
-    console.log('fd:', filteredDictionaries);
   }
 
   let searchBlurTimeout;


### PR DESCRIPTION

#### Relevant Issue
Avoid showing duplicates when searching for dictionaries
#### Summarize what changed in this PR (for developers)
I added a reduce function after filter dictionaries
#### Summarize changes in this PR (for public-facing changelog)
No more duplicates in the search input
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-9610h7ehr-livingtongues.vercel.app/


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/99"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

