### PR TITLE
Add automatically dictionaries managing

### DIFF
--- a/src/lib/helpers/dictionariesManaging.ts
+++ b/src/lib/helpers/dictionariesManaging.ts
@@ -3,14 +3,14 @@ import { arrayRemove, arrayUnion, serverTimestamp } from 'firebase/firestore/lit
 import type { IUser, IManager } from '$lib/interfaces';
 
 export async function addDictionaryManagePermission(userBeingEdited: IUser, dictionaryId: string) {
-  const manager: IManager = {
+  await set<IManager>(`dictionaries/${dictionaryId}/managers/${userBeingEdited.uid}`, {
     id: userBeingEdited.uid,
     name: userBeingEdited.displayName,
-  };
-
-  await set(`dictionaries/${dictionaryId}/managers/${userBeingEdited.uid}`, manager);
-  await update(`users/${userBeingEdited.uid}`, {
+  });
+  await update<IUser>(`users/${userBeingEdited.uid}`, {
+    //@ts-ignore
     managing: arrayUnion(dictionaryId),
+    //@ts-ignore
     termsAgreement: serverTimestamp(),
   });
 }

--- a/src/lib/interfaces/dictionary.interface.ts
+++ b/src/lib/interfaces/dictionary.interface.ts
@@ -11,7 +11,7 @@ export interface IDictionary extends IFirestoreMetaData {
   glottocode?: string;
   coordinates?: GeoPoint;
   public?: boolean;
-  entryCount: number; // number | firebase.firestore.FieldValue;
+  entryCount: number; // number | FieldValue;
   copyright?: string; // Allow custom copyright in case "Copyright _______ community" isn't appropriate for dictionary (eg. Tehuelche)
   alternateOrthographies?: string[]; // Alternate Orthography titles (first item corresponds to entry.lo, then entry.lo2, entry.lo3) - used to be called Local Orthography but that is a misnomer it's turning out
 

--- a/src/lib/interfaces/user.interface.ts
+++ b/src/lib/interfaces/user.interface.ts
@@ -11,7 +11,7 @@ interface User {
   lastVisit?: Timestamp & FieldValue;
 
   roles?: IRoles;
-  managing?: string[]; // | firebase.firestore.FieldValue; // dictionary Ids
+  managing?: string[]; // | FieldValue; // dictionary Ids
   contributing?: string[]; // dictionary Ids
   // starred?: string[]; // in future save dictionary Ids to user that they star, to allow them quick access back to those dictionaries
   termsAgreement?: Timestamp & FieldValue;

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -8,7 +8,7 @@
   import Button from '$svelteui/ui/Button.svelte';
   import type { IDictionary, IManager, IUser } from '$lib/interfaces';
   import { docExists, setOnline, updateOnline } from '$sveltefire/lite';
-  import { GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
+  import { arrayUnion, GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
   import { debounce } from '$lib/helpers/debounce';
   import { addDictionaryManagePermission } from '$lib/helpers/dictionariesManaging';
 
@@ -93,7 +93,7 @@
       });
       await updateOnline<IUser>(`users/${$user.uid}`, {
         //@ts-ignore
-        managing: arrayUnion(dictionaryId),
+        managing: arrayUnion(url),
         // WARNING: If we are going to make a delete dictionary option available to users, we must delete the corresponding management data in the user interface
         //@ts-ignore
         termsAgreement: serverTimestamp(),

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -10,7 +10,6 @@
   import { docExists, setOnline, updateOnline } from '$sveltefire/lite';
   import { arrayUnion, GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
   import { debounce } from '$lib/helpers/debounce';
-  import { addDictionaryManagePermission } from '$lib/helpers/dictionariesManaging';
 
   let modal: 'auth' | 'coordinates' = null;
   let submitting = false;
@@ -126,8 +125,7 @@
 <Header
   >{$_('create.create_new_dictionary', {
     default: 'Create New Dictionary',
-  })}</Header
->
+  })}</Header>
 
 <form class="flex" on:submit|preventDefault={createNewDictionary}>
   <div class="flex flex-col justify-center p-4 max-w-md mx-auto">
@@ -147,8 +145,7 @@
           minlength="3"
           required
           bind:value={name}
-          class="form-input w-full"
-        />
+          class="form-input w-full" />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.name_clarification', {
@@ -165,8 +162,7 @@
       <div class="mt-1 flex rounded-md shadow-sm" style="direction: ltr">
         <span
           class="inline-flex items-center px-2 rounded-l-md border border-r-0
-            border-gray-300 bg-gray-50 text-gray-500 text-sm"
-        >
+            border-gray-300 bg-gray-50 text-gray-500 text-sm">
           livingdictionaries.app/
         </span>
         <input
@@ -180,8 +176,7 @@
           spellcheck={false}
           class="form-input flex-1 block w-full px-2 sm:px-3 py-2 rounded-none
             rounded-r-md sm:text-sm sm:leading-5"
-          placeholder="url"
-        />
+          placeholder="url" />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.only_letters_numbers', {
@@ -207,8 +202,7 @@
       <div class="mt-1 rounded-md shadow-sm" style="direction: ltr">
         <MultiSelect
           bind:value={glossLanguages}
-          placeholder={$_('create.languages', { default: 'Language(s)' })}
-        >
+          placeholder={$_('create.languages', { default: 'Language(s)' })}>
           {#each Object.keys(glossingLanguages) as bcp}
             <option value={bcp}>
               {glossingLanguages[bcp].vernacularName || $_('gl.' + bcp)}
@@ -261,8 +255,7 @@
         promptMessage={$_('create.enter_alternate_name', {
           default: 'Enter Alternate Name',
         })}
-        addMessage={$_('misc.add', { default: 'Add' })}
-      />
+        addMessage={$_('misc.add', { default: 'Add' })} />
     </div>
     <div class="mt-6 flex">
       <div class="w-1/2">
@@ -271,8 +264,7 @@
           <a
             href="https://en.wikipedia.org/wiki/ISO_639-3"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800"
-          >
+            class="text-gray-600 hover:text-gray:800">
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -286,8 +278,7 @@
             minlength="3"
             maxlength="3"
             bind:value={iso6393}
-            class="form-input w-full"
-          />
+            class="form-input w-full" />
         </div>
       </div>
       <div class="w-1" />
@@ -297,8 +288,7 @@
           <a
             href="https://en.wikipedia.org/wiki/Glottolog"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800"
-          >
+            class="text-gray-600 hover:text-gray:800">
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -311,8 +301,7 @@
             spellcheck={false}
             minlength="3"
             bind:value={glottocode}
-            class="form-input w-full"
-          />
+            class="form-input w-full" />
         </div>
       </div>
     </div>
@@ -335,8 +324,7 @@
               publicDictionary = false;
             }
           }, 5);
-        }}
-      />
+        }} />
       <label for="public" class="mx-2 block text-sm leading-5 text-gray-900">
         {$_('create.visible_to_public', { default: 'Visible to Public' })}
         <small class="text-gray-600">
@@ -379,8 +367,7 @@
       }}
       on:remove={() => {
         (lat = null), (lng = null);
-      }}
-    />
+      }} />
   {/await}
 {/if}
 
@@ -390,7 +377,6 @@
       context="force"
       on:close={() => {
         modal = null;
-      }}
-    />
+      }} />
   {/await}
 {/if}

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -87,18 +87,17 @@
         glottocode: glottocode.trim(),
       };
       await setOnline<IDictionary>(`dictionaries/${url}`, dictionaryData);
-      const manager = {
+      await setOnline<IManager>(`dictionaries/${url}/managers/${$user.uid}`, {
         id: $user.uid,
         name: $user.displayName,
-      };
-      await setOnline<IManager>(`dictionaries/${url}/managers/${$user.uid}`, manager);
+      });
       await updateOnline<IUser>(`users/${$user.uid}`, {
+        //@ts-ignore
+        managing: arrayUnion(dictionaryId),
+        // WARNING: If we are going to make a delete dictionary option available to users, we must delete the corresponding management data in the user interface
         //@ts-ignore
         termsAgreement: serverTimestamp(),
       });
-      // This handles User data
-      // WARNING: If we are going to make a delete dictionary option available to users, we must delete the corresponding management data in the user interface
-      addDictionaryManagePermission($user, url);
       window.location.replace(`/${url}/entries/list`);
     } catch (err) {
       alert(`${$_('misc.error', { default: 'Error' })}: ${err}`);
@@ -127,7 +126,8 @@
 <Header
   >{$_('create.create_new_dictionary', {
     default: 'Create New Dictionary',
-  })}</Header>
+  })}</Header
+>
 
 <form class="flex" on:submit|preventDefault={createNewDictionary}>
   <div class="flex flex-col justify-center p-4 max-w-md mx-auto">
@@ -147,7 +147,8 @@
           minlength="3"
           required
           bind:value={name}
-          class="form-input w-full" />
+          class="form-input w-full"
+        />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.name_clarification', {
@@ -164,7 +165,8 @@
       <div class="mt-1 flex rounded-md shadow-sm" style="direction: ltr">
         <span
           class="inline-flex items-center px-2 rounded-l-md border border-r-0
-            border-gray-300 bg-gray-50 text-gray-500 text-sm">
+            border-gray-300 bg-gray-50 text-gray-500 text-sm"
+        >
           livingdictionaries.app/
         </span>
         <input
@@ -178,7 +180,8 @@
           spellcheck={false}
           class="form-input flex-1 block w-full px-2 sm:px-3 py-2 rounded-none
             rounded-r-md sm:text-sm sm:leading-5"
-          placeholder="url" />
+          placeholder="url"
+        />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.only_letters_numbers', {
@@ -204,7 +207,8 @@
       <div class="mt-1 rounded-md shadow-sm" style="direction: ltr">
         <MultiSelect
           bind:value={glossLanguages}
-          placeholder={$_('create.languages', { default: 'Language(s)' })}>
+          placeholder={$_('create.languages', { default: 'Language(s)' })}
+        >
           {#each Object.keys(glossingLanguages) as bcp}
             <option value={bcp}>
               {glossingLanguages[bcp].vernacularName || $_('gl.' + bcp)}
@@ -257,7 +261,8 @@
         promptMessage={$_('create.enter_alternate_name', {
           default: 'Enter Alternate Name',
         })}
-        addMessage={$_('misc.add', { default: 'Add' })} />
+        addMessage={$_('misc.add', { default: 'Add' })}
+      />
     </div>
     <div class="mt-6 flex">
       <div class="w-1/2">
@@ -266,7 +271,8 @@
           <a
             href="https://en.wikipedia.org/wiki/ISO_639-3"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800">
+            class="text-gray-600 hover:text-gray:800"
+          >
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -280,7 +286,8 @@
             minlength="3"
             maxlength="3"
             bind:value={iso6393}
-            class="form-input w-full" />
+            class="form-input w-full"
+          />
         </div>
       </div>
       <div class="w-1" />
@@ -290,7 +297,8 @@
           <a
             href="https://en.wikipedia.org/wiki/Glottolog"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800">
+            class="text-gray-600 hover:text-gray:800"
+          >
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -303,7 +311,8 @@
             spellcheck={false}
             minlength="3"
             bind:value={glottocode}
-            class="form-input w-full" />
+            class="form-input w-full"
+          />
         </div>
       </div>
     </div>
@@ -326,7 +335,8 @@
               publicDictionary = false;
             }
           }, 5);
-        }} />
+        }}
+      />
       <label for="public" class="mx-2 block text-sm leading-5 text-gray-900">
         {$_('create.visible_to_public', { default: 'Visible to Public' })}
         <small class="text-gray-600">
@@ -369,7 +379,8 @@
       }}
       on:remove={() => {
         (lat = null), (lng = null);
-      }} />
+      }}
+    />
   {/await}
 {/if}
 
@@ -379,6 +390,7 @@
       context="force"
       on:close={() => {
         modal = null;
-      }} />
+      }}
+    />
   {/await}
 {/if}

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -10,6 +10,7 @@
   import { docExists, setOnline, updateOnline } from '$sveltefire/lite';
   import { GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
   import { debounce } from '$lib/helpers/debounce';
+  import { addDictionaryManagePermission } from '$lib/helpers/dictionariesManaging';
 
   let modal: 'auth' | 'coordinates' = null;
   let submitting = false;
@@ -95,6 +96,7 @@
         //@ts-ignore
         termsAgreement: serverTimestamp(),
       });
+      addDictionaryManagePermission($user, url);
       window.location.replace(`/${url}/entries/list`);
     } catch (err) {
       alert(`${$_('misc.error', { default: 'Error' })}: ${err}`);

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -96,6 +96,8 @@
         //@ts-ignore
         termsAgreement: serverTimestamp(),
       });
+      // This handles User data
+      // WARNING: If we are going to make a delete dictionary option available to users, we must delete the corresponding management data in the user interface
       addDictionaryManagePermission($user, url);
       window.location.replace(`/${url}/entries/list`);
     } catch (err) {


### PR DESCRIPTION
#### Relevant Issue
#91 
#### Summarize what changed in this PR (for developers)
We are updating the array of managing dictionaries when a user creates a new one   
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/152865218-4a0c620f-a82f-4605-8d4d-e961b6de7737.png)
When you create a new dictionary, it is automatically added to the list of  the DICTIONARIES MANAGING.
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
You can create a dictionary [here](https://living-dictionaries-695e2ynig-livingtongues.vercel.app/create-dictionary) and then see in https://living-dictionaries-695e2ynig-livingtongues.vercel.app/admin/users that the dictionary was added automatically (you can only see the admin/users page if you are an admin)


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/100"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

