### PR TITLE
propose of delete-object-empty-fields function in a hepler/delete file

### DIFF
--- a/src/lib/helpers/delete.ts
+++ b/src/lib/helpers/delete.ts
@@ -24,11 +24,3 @@ export async function deleteAudio(entry: IEntry) {
     alert(`${$_('misc.error', { default: 'Error' })}: ${err}`);
   }
 }
-
-export function deleteObjectEmptyFields(ObjData: any) {
-  for (const key in ObjData) {
-    if (ObjData[key] === '' || ObjData[key] === undefined || ObjData[key] === null) {
-      delete ObjData[key];
-    }
-  }
-}

--- a/src/lib/helpers/delete.ts
+++ b/src/lib/helpers/delete.ts
@@ -24,3 +24,11 @@ export async function deleteAudio(entry: IEntry) {
     alert(`${$_('misc.error', { default: 'Error' })}: ${err}`);
   }
 }
+
+export function deleteObjectEmptyFields(ObjData: any) {
+  for (const key in ObjData) {
+    if (ObjData[key] === '' || ObjData[key] === undefined || ObjData[key] === null) {
+      delete ObjData[key];
+    }
+  }
+}

--- a/src/lib/helpers/prune.test.ts
+++ b/src/lib/helpers/prune.test.ts
@@ -1,0 +1,39 @@
+import { pruneObject } from './prune';
+
+test('pruneObject removes empty string, empty array, null, false, and undefined at root and nested level', () => {
+  expect(
+    pruneObject({
+      id: '1234',
+      myArrayWithStuff: ['test'],
+      emptyString: '',
+      emptyArray: [],
+      foo: null,
+      baz: false,
+      bar: undefined,
+      nested: {
+        name: 'test',
+        withStuff: ['hello', 'world'],
+        en: '',
+        emptyArray: [],
+        zh: null,
+        de: null,
+        show: false,
+        that: undefined,
+      },
+    })
+  ).toMatchInlineSnapshot(`
+    Object {
+      "id": "1234",
+      "myArrayWithStuff": Array [
+        "test",
+      ],
+      "nested": Object {
+        "name": "test",
+        "withStuff": Array [
+          "hello",
+          "world",
+        ],
+      },
+    }
+  `);
+});

--- a/src/lib/helpers/prune.ts
+++ b/src/lib/helpers/prune.ts
@@ -1,0 +1,13 @@
+export function pruneObject<T>(obj: T) {
+  const prunedObject = {} as T;
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] != null && obj[key] != '' && obj[key] != []) {
+      if (obj[key] instanceof Object && !(obj[key] instanceof Array)) {
+        prunedObject[key] = pruneObject(obj[key]);
+      } else {
+        prunedObject[key] = obj[key];
+      }
+    }
+  });
+  return prunedObject;
+}

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -10,6 +10,7 @@
   import { docExists, setOnline, updateOnline } from '$sveltefire/lite';
   import { arrayUnion, GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
   import { debounce } from '$lib/helpers/debounce';
+  import { deleteObjectEmptyFields } from '$lib/helpers/delete';
 
   let modal: 'auth' | 'coordinates' = null;
   let submitting = false;
@@ -73,7 +74,6 @@
     }
     try {
       submitting = true;
-      // TODO: don't add fields that are empty
       const dictionaryData = {
         name: name.trim().replace(/^./, name[0].toUpperCase()),
         glossLanguages,
@@ -85,6 +85,9 @@
         iso6393: iso6393.trim(),
         glottocode: glottocode.trim(),
       };
+      // Deleting empty fields
+      deleteObjectEmptyFields(dictionaryData);
+
       await setOnline<IDictionary>(`dictionaries/${url}`, dictionaryData);
       await setOnline<IManager>(`dictionaries/${url}/managers/${$user.uid}`, {
         id: $user.uid,

--- a/src/routes/create-dictionary.svelte
+++ b/src/routes/create-dictionary.svelte
@@ -10,7 +10,7 @@
   import { docExists, setOnline, updateOnline } from '$sveltefire/lite';
   import { arrayUnion, GeoPoint, serverTimestamp } from 'firebase/firestore/lite';
   import { debounce } from '$lib/helpers/debounce';
-  import { deleteObjectEmptyFields } from '$lib/helpers/delete';
+  import { pruneObject } from '$lib/helpers/prune';
 
   let modal: 'auth' | 'coordinates' = null;
   let submitting = false;
@@ -30,7 +30,7 @@
   $: {
     url = url
       .trim()
-      .substr(0, 25) // Max 25 characters
+      .slice(0, 25) // Max 25 characters
       .trim()
       .replace(/\s+/g, '-') // Replace string-medial spaces with hyphens
       .replace(/[';,!@#$%^&*()]/g, '') // Remove special characters
@@ -74,7 +74,7 @@
     }
     try {
       submitting = true;
-      const dictionaryData = {
+      const dictionaryData: IDictionary = {
         name: name.trim().replace(/^./, name[0].toUpperCase()),
         glossLanguages,
         public: publicDictionary,
@@ -85,10 +85,8 @@
         iso6393: iso6393.trim(),
         glottocode: glottocode.trim(),
       };
-      // Deleting empty fields
-      deleteObjectEmptyFields(dictionaryData);
 
-      await setOnline<IDictionary>(`dictionaries/${url}`, dictionaryData);
+      await setOnline<IDictionary>(`dictionaries/${url}`, pruneObject(dictionaryData));
       await setOnline<IManager>(`dictionaries/${url}/managers/${$user.uid}`, {
         id: $user.uid,
         name: $user.displayName,
@@ -128,7 +126,8 @@
 <Header
   >{$_('create.create_new_dictionary', {
     default: 'Create New Dictionary',
-  })}</Header>
+  })}</Header
+>
 
 <form class="flex" on:submit|preventDefault={createNewDictionary}>
   <div class="flex flex-col justify-center p-4 max-w-md mx-auto">
@@ -148,7 +147,8 @@
           minlength="3"
           required
           bind:value={name}
-          class="form-input w-full" />
+          class="form-input w-full"
+        />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.name_clarification', {
@@ -165,7 +165,8 @@
       <div class="mt-1 flex rounded-md shadow-sm" style="direction: ltr">
         <span
           class="inline-flex items-center px-2 rounded-l-md border border-r-0
-            border-gray-300 bg-gray-50 text-gray-500 text-sm">
+            border-gray-300 bg-gray-50 text-gray-500 text-sm"
+        >
           livingdictionaries.app/
         </span>
         <input
@@ -179,7 +180,8 @@
           spellcheck={false}
           class="form-input flex-1 block w-full px-2 sm:px-3 py-2 rounded-none
             rounded-r-md sm:text-sm sm:leading-5"
-          placeholder="url" />
+          placeholder="url"
+        />
       </div>
       <div class="text-xs text-gray-600 mt-1">
         {$_('create.only_letters_numbers', {
@@ -205,7 +207,8 @@
       <div class="mt-1 rounded-md shadow-sm" style="direction: ltr">
         <MultiSelect
           bind:value={glossLanguages}
-          placeholder={$_('create.languages', { default: 'Language(s)' })}>
+          placeholder={$_('create.languages', { default: 'Language(s)' })}
+        >
           {#each Object.keys(glossingLanguages) as bcp}
             <option value={bcp}>
               {glossingLanguages[bcp].vernacularName || $_('gl.' + bcp)}
@@ -258,7 +261,8 @@
         promptMessage={$_('create.enter_alternate_name', {
           default: 'Enter Alternate Name',
         })}
-        addMessage={$_('misc.add', { default: 'Add' })} />
+        addMessage={$_('misc.add', { default: 'Add' })}
+      />
     </div>
     <div class="mt-6 flex">
       <div class="w-1/2">
@@ -267,7 +271,8 @@
           <a
             href="https://en.wikipedia.org/wiki/ISO_639-3"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800">
+            class="text-gray-600 hover:text-gray:800"
+          >
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -281,7 +286,8 @@
             minlength="3"
             maxlength="3"
             bind:value={iso6393}
-            class="form-input w-full" />
+            class="form-input w-full"
+          />
         </div>
       </div>
       <div class="w-1" />
@@ -291,7 +297,8 @@
           <a
             href="https://en.wikipedia.org/wiki/Glottolog"
             target="_blank"
-            class="text-gray-600 hover:text-gray:800">
+            class="text-gray-600 hover:text-gray:800"
+          >
             <i class="far fa-info-circle" />
           </a>
         </label>
@@ -304,7 +311,8 @@
             spellcheck={false}
             minlength="3"
             bind:value={glottocode}
-            class="form-input w-full" />
+            class="form-input w-full"
+          />
         </div>
       </div>
     </div>
@@ -327,7 +335,8 @@
               publicDictionary = false;
             }
           }, 5);
-        }} />
+        }}
+      />
       <label for="public" class="mx-2 block text-sm leading-5 text-gray-900">
         {$_('create.visible_to_public', { default: 'Visible to Public' })}
         <small class="text-gray-600">
@@ -370,7 +379,8 @@
       }}
       on:remove={() => {
         (lat = null), (lng = null);
-      }} />
+      }}
+    />
   {/await}
 {/if}
 
@@ -380,6 +390,7 @@
       context="force"
       on:close={() => {
         modal = null;
-      }} />
+      }}
+    />
   {/await}
 {/if}


### PR DESCRIPTION
#### Relevant Issue
N/A
#### Summarize what changed in this PR (for developers)
I added a new delete-object-empty-fields function in a helpers/delete file (don't know if it fits well there)
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/153258143-ee232ee0-51b8-4894-a6d8-817a32cd458f.png)
We are not storing fields with null, undefined or empty strings in our DB anymore when a user creates a new dictionary (note we're still storing empty arrays)
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
Create a new dictionary [here](https://living-dictionaries-c59ojh2vg-livingtongues.vercel.app/create-dictionary) and see how it is stored on Firestore

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/103"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

