### PR TITLE
Ckeditor on edit entry fields

### DIFF
--- a/src/lib/components/editor/ClassicCustomized.svelte
+++ b/src/lib/components/editor/ClassicCustomized.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let html: string;
-  export let englishGloss = false;
+  export let limitedToolbar: string[] = [];
   import CKEditor from './CKEditor.svelte';
   import { onMount } from 'svelte';
   let editor: any;
@@ -31,13 +31,8 @@
     ],
   };
 
-  //TODO make it for every other case and make it legible
-  if (englishGloss) {
-    editorConfig.toolbar = [
-      editorConfig.toolbar[editorConfig.toolbar.indexOf('bold')],
-      editorConfig.toolbar[editorConfig.toolbar.indexOf('italic')],
-      editorConfig.toolbar[editorConfig.toolbar.indexOf('link')],
-    ];
+  if (limitedToolbar.length > 0) {
+    editorConfig.toolbar = limitedToolbar;
   }
 
   let mounted = false;

--- a/src/lib/components/editor/ClassicCustomized.svelte
+++ b/src/lib/components/editor/ClassicCustomized.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   export let html: string;
+  export let englishGloss = false;
   import CKEditor from './CKEditor.svelte';
   import { onMount } from 'svelte';
   let editor: any;
@@ -29,6 +30,15 @@
       'redo',
     ],
   };
+
+  //TODO make it for every other case and make it legible
+  if (englishGloss) {
+    editorConfig.toolbar = [
+      editorConfig.toolbar[editorConfig.toolbar.indexOf('bold')],
+      editorConfig.toolbar[editorConfig.toolbar.indexOf('italic')],
+      editorConfig.toolbar[editorConfig.toolbar.indexOf('link')],
+    ];
+  }
 
   let mounted = false;
   onMount(async () => {

--- a/src/lib/components/modals/EditFieldModal.svelte
+++ b/src/lib/components/modals/EditFieldModal.svelte
@@ -33,7 +33,7 @@
 <Modal on:close>
   <span slot="heading">{display}</span>
   <form on:submit|preventDefault={save}>
-    {#if field === 'gl.en'}
+    {#if field.startsWith('gl.')}
       {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
         <ClassicCustomized bind:html={value} limitedToolbar={['bold', 'italic', 'link']} />
       {/await}

--- a/src/lib/components/modals/EditFieldModal.svelte
+++ b/src/lib/components/modals/EditFieldModal.svelte
@@ -33,10 +33,19 @@
 <Modal on:close>
   <span slot="heading">{display}</span>
   <form on:submit|preventDefault={save}>
-    <!-- TODO fix for every different case -->
-    {#if field === 'gl.en' || field === 'in' || field === 'nt'}
+    {#if field === 'gl.en'}
       {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
-        <ClassicCustomized bind:html={value} englishGloss />
+        <ClassicCustomized bind:html={value} limitedToolbar={['bold', 'italic', 'link']} />
+      {/await}
+    {:else if field === 'in'}
+      {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
+        <ClassicCustomized
+          bind:html={value}
+          limitedToolbar={['bold', 'italic', 'smallCaps', 'link']} />
+      {/await}
+    {:else if field === 'nt'}
+      {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
+        <ClassicCustomized bind:html={value} />
       {/await}
     {:else}
       <div>

--- a/src/lib/components/modals/EditFieldModal.svelte
+++ b/src/lib/components/modals/EditFieldModal.svelte
@@ -33,19 +33,25 @@
 <Modal on:close>
   <span slot="heading">{display}</span>
   <form on:submit|preventDefault={save}>
-    <div>
-      <!-- <label for="email" class="block text-sm font-medium leading-5 text-gray-700">Email</label> -->
-      <div class="rounded-md shadow-sm">
-        <input
-          dir="ltr"
-          type="text"
-          required={field === 'lx'}
-          use:autofocus
-          bind:value
-          class:sompeng={display === 'Sompeng-Mardir'}
-          class="form-input block w-full" />
+    {#if field === 'gl.en' || field === 'in' || field === 'nt'}
+      {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
+        <ClassicCustomized bind:html={value} />
+      {/await}
+    {:else}
+      <div>
+        <!-- <label for="email" class="block text-sm font-medium leading-5 text-gray-700">Email</label> -->
+        <div class="rounded-md shadow-sm">
+          <input
+            dir="ltr"
+            type="text"
+            required={field === 'lx'}
+            use:autofocus
+            bind:value
+            class:sompeng={display === 'Sompeng-Mardir'}
+            class="form-input block w-full" />
+        </div>
       </div>
-    </div>
+    {/if}
 
     <div class="modal-footer space-x-1">
       <Button onclick={close} form="simple" color="black">

--- a/src/lib/components/modals/EditFieldModal.svelte
+++ b/src/lib/components/modals/EditFieldModal.svelte
@@ -33,9 +33,10 @@
 <Modal on:close>
   <span slot="heading">{display}</span>
   <form on:submit|preventDefault={save}>
+    <!-- TODO fix for every different case -->
     {#if field === 'gl.en' || field === 'in' || field === 'nt'}
       {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
-        <ClassicCustomized bind:html={value} />
+        <ClassicCustomized bind:html={value} englishGloss />
       {/await}
     {:else}
       <div>

--- a/src/lib/helpers/replaceHTMLTags.test.ts
+++ b/src/lib/helpers/replaceHTMLTags.test.ts
@@ -1,0 +1,18 @@
+import { replaceHTMLTags } from './replaceHTMLTags';
+
+test('Simple text wrapped in HTML tags', () =>
+  expect(replaceHTMLTags('<strong>test</strong>')).toBe('test'));
+
+test('Simple text wrapped in HTML tags with styles', () =>
+  expect(
+    replaceHTMLTags(
+      '<p><strong>testing </strong><i><strong>just </strong></i><span style="font-variant:small-caps;"><strong>testing</strong></span></p>'
+    )
+  ).toBe('testing just testing'));
+
+test('complex HTML tags wrap text around', () =>
+  expect(
+    replaceHTMLTags(
+      '<figure class="table"><table><tbody><tr><td>d</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>d</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td><td>d</td></tr></tbody></table></figure>'
+    )
+  ).toBe('d d d'));

--- a/src/lib/helpers/replaceHTMLTags.ts
+++ b/src/lib/helpers/replaceHTMLTags.ts
@@ -1,0 +1,9 @@
+const regexForRichText = /<\w+>|<\/\w+>|<\w+ \w+="[a-z:\-/.]+(;*)">|&nbsp;/g;
+
+export function replaceHTMLTags(text: string): string {
+  return text
+    .replace(regexForRichText, ' ')
+    .trim()
+    .split(/[\s,\t,\n]+/)
+    .join(' ');
+}

--- a/src/routes/[dictionaryId]/entries/_ListEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_ListEntry.svelte
@@ -45,7 +45,7 @@
         {#if entry.ps}
           <i>{$_('psAbbrev.' + entry.ps, { default: entry.ps })},</i>
         {/if}
-        {printGlosses(entry.gl).join(', ')}
+        {@html printGlosses(entry.gl).join(', ')}
       </div>
       {#if entry.sd}
         <span class="px-2 py-1 leading-tight text-xs bg-gray-100 rounded ml-1">

--- a/src/routes/[dictionaryId]/entry/_EntryField.svelte
+++ b/src/routes/[dictionaryId]/entry/_EntryField.svelte
@@ -23,7 +23,7 @@
         {#if value}
           <div dir="ltr">
             <!-- prettier-ignore -->
-            {#if field === 'ph'}[{/if}{value}{#if field === 'ph'}]{/if}
+            {#if field === 'ph'}[{/if}{@html value}{#if field === 'ph'}]{/if}
           </div>
         {:else}<i class="far fa-pencil text-gray-500 text-sm" />{/if}
       </div>

--- a/src/routes/[dictionaryId]/export/_formatEntries.ts
+++ b/src/routes/[dictionaryId]/export/_formatEntries.ts
@@ -38,6 +38,8 @@ export function formatEntriesForCSV(
     '"': "'",
   };
 
+  const regexForRichText = /<\w+>|<\/\w+>|<\w+ \w+='[a-z:\-/.]+(;*)'>|&nbsp;/g;
+
   const headers = {
     id: 'Entry id',
     lx: 'Lexeme/Word/Phrase',
@@ -91,10 +93,14 @@ export function formatEntriesForCSV(
       id: entry.id,
       lx: entry.lx.replace(/[,"\r\n]/g, (m) => replacementChars[m]),
       ph: entry.ph ? entry.ph.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
-      in: entry.in ? entry.in.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
+      in: entry.in
+        ? entry.in.replace(/[,"\r\n]/g, (m) => replacementChars[m]).replace(regexForRichText, ' ')
+        : '',
       mr: entry.mr ? entry.mr.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
       di: entry.di ? entry.di.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
-      nt: entry.nt ? entry.nt.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
+      nt: entry.nt
+        ? entry.nt.replace(/[,"\r\n]/g, (m) => replacementChars[m]).replace(regexForRichText, ' ')
+        : '',
       //xv: entry.xv,
     });
 
@@ -145,7 +151,9 @@ export function formatEntriesForCSV(
     //Assigning glosses
     glossLanguages.forEach((bcp) => {
       const cleanEntry = entry.gl[bcp]
-        ? entry.gl[bcp].replace(/[,"\r\n]/g, (m) => replacementChars[m])
+        ? entry.gl[bcp]
+            .replace(/[,"\r\n]/g, (m) => replacementChars[m])
+            .replace(regexForRichText, ' ')
         : '';
       itemsFormatted[i][`gl${bcp}`] = cleanEntry;
     });

--- a/src/routes/[dictionaryId]/export/_formatEntries.ts
+++ b/src/routes/[dictionaryId]/export/_formatEntries.ts
@@ -3,6 +3,7 @@ import { glossingLanguages } from './_glossing-languages-temp';
 import { semanticDomains } from '$lib/mappings/semantic-domains';
 import { partsOfSpeech } from '$lib/mappings/parts-of-speech';
 import { friendlyName } from '$lib/helpers/friendlyName';
+import { replaceHTMLTags } from '$lib/helpers/replaceHTMLTags';
 
 function turnArrayIntoPipedString(itemsFormatted, i, values, columnName, fn) {
   if (values) {
@@ -37,8 +38,6 @@ export function formatEntriesForCSV(
     ',': ' -',
     '"': "'",
   };
-
-  const regexForRichText = /<\w+>|<\/\w+>|<\w+ \w+='[a-z:\-/.]+(;*)'>|&nbsp;/g;
 
   const headers = {
     id: 'Entry id',
@@ -94,12 +93,12 @@ export function formatEntriesForCSV(
       lx: entry.lx.replace(/[,"\r\n]/g, (m) => replacementChars[m]),
       ph: entry.ph ? entry.ph.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
       in: entry.in
-        ? entry.in.replace(/[,"\r\n]/g, (m) => replacementChars[m]).replace(regexForRichText, ' ')
+        ? replaceHTMLTags(entry.in.replace(/[,"\r\n]/g, (m) => replacementChars[m]))
         : '',
       mr: entry.mr ? entry.mr.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
       di: entry.di ? entry.di.replace(/[,"\r\n]/g, (m) => replacementChars[m]) : '',
       nt: entry.nt
-        ? entry.nt.replace(/[,"\r\n]/g, (m) => replacementChars[m]).replace(regexForRichText, ' ')
+        ? replaceHTMLTags(entry.nt.replace(/[,"\r\n]/g, (m) => replacementChars[m]))
         : '',
       //xv: entry.xv,
     });
@@ -151,9 +150,7 @@ export function formatEntriesForCSV(
     //Assigning glosses
     glossLanguages.forEach((bcp) => {
       const cleanEntry = entry.gl[bcp]
-        ? entry.gl[bcp]
-            .replace(/[,"\r\n]/g, (m) => replacementChars[m])
-            .replace(regexForRichText, ' ')
+        ? replaceHTMLTags(entry.gl[bcp].replace(/[,"\r\n]/g, (m) => replacementChars[m]))
         : '';
       itemsFormatted[i][`gl${bcp}`] = cleanEntry;
     });


### PR DESCRIPTION
#### Relevant Issue
#110 
#### Summarize what changed in this PR (for developers)
Make the ClassicCustomized component more customized and add those changes in the pertinent editable entry fields. Storing new data as a string that contains html tags. 
#### Summarize changes in this PR (for public-facing changelog)
The english gloss, interlinearization and notes modals now contains a CKEditor for styling the data
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
try to edit english gloss, interlinearization and notes: https://living-dictionaries-hf4owow2q-livingtongues.vercel.app/akateko/entry/tChfJAqRIuNGdO8dnDrn 


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

