### PR TITLE
Fix gallery max size images

### DIFF
--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -3,16 +3,11 @@
   import Image from '$lib/components/image/Image.svelte';
   export let entry: IEntry;
   export let canEdit = false;
-  export let maxSizeImage = false;
   import { dictionary } from '$lib/stores';
   let innerWidth: number;
 </script>
 
-<svelte:window bind:innerWidth />
-
-<div
-  class={`flex flex-col relative rounded ${maxSizeImage && innerWidth >= 1280 ? 'mb-16' : ''}`}
-  style="max-width: 500px; max-height: 500px;">
+<div class="flex flex-col relative rounded max-w-[500px]">
   <div class="bg-gray-300 shadow">
     <div class="aspect-square overflow-hidden">
       <Image square={480} {entry} {canEdit} />

--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -5,10 +5,13 @@
   export let canEdit = false;
   export let maxSizeImage = false;
   import { dictionary } from '$lib/stores';
+  let innerWidth: number;
 </script>
 
+<svelte:window bind:innerWidth />
+
 <div
-  class={`flex flex-col relative rounded ${maxSizeImage ? 'mb-16' : ''}`}
+  class={`flex flex-col relative rounded ${maxSizeImage && innerWidth >= 1280 ? 'mb-16' : ''}`}
   style="max-width: 500px; max-height: 500px;">
   <div class="bg-gray-300 shadow">
     <div class="aspect-square overflow-hidden">

--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -3,10 +3,13 @@
   import Image from '$lib/components/image/Image.svelte';
   export let entry: IEntry;
   export let canEdit = false;
+  export let maxSizeImage = false;
   import { dictionary } from '$lib/stores';
 </script>
 
-<div class="flex flex-col relative rounded" style="max-width: 500px; max-height: 500px;">
+<div
+  class={`flex flex-col relative rounded ${maxSizeImage ? 'mb-16' : ''}`}
+  style="max-width: 500px; max-height: 500px;">
   <div class="bg-gray-300 shadow">
     <div class="aspect-square overflow-hidden">
       <Image square={480} {entry} {canEdit} />

--- a/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
+++ b/src/routes/[dictionaryId]/entries/_GalleryEntry.svelte
@@ -4,7 +4,6 @@
   export let entry: IEntry;
   export let canEdit = false;
   import { dictionary } from '$lib/stores';
-  let innerWidth: number;
 </script>
 
 <div class="flex flex-col relative rounded max-w-[500px]">

--- a/src/routes/[dictionaryId]/entries/gallery.svelte
+++ b/src/routes/[dictionaryId]/entries/gallery.svelte
@@ -50,10 +50,7 @@
             path="dictionaries/{$dictionary.id}/words/{algoliaEntry.id}"
             startWith={algoliaEntry}
             let:data={entry}>
-            <GalleryEntry
-              {entry}
-              canEdit={$canEdit}
-              maxSizeImage={entries.length <= 2 ? true : false} />
+            <GalleryEntry {entry} canEdit={$canEdit} />
           </Doc>
         {/if}
       {/each}

--- a/src/routes/[dictionaryId]/entries/gallery.svelte
+++ b/src/routes/[dictionaryId]/entries/gallery.svelte
@@ -50,7 +50,10 @@
             path="dictionaries/{$dictionary.id}/words/{algoliaEntry.id}"
             startWith={algoliaEntry}
             let:data={entry}>
-            <GalleryEntry {entry} canEdit={$canEdit} />
+            <GalleryEntry
+              {entry}
+              canEdit={$canEdit}
+              maxSizeImage={entries.length <= 2 ? true : false} />
           </Doc>
         {/if}
       {/each}


### PR DESCRIPTION
#### Relevant Issue
Images in gallery view don't display text when they reach their maximum size
#### Summarize what changed in this PR (for developers)
I added a dynamic tailwind class instead of the style attribute
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/157746599-36e00057-3588-4d2f-8e3d-437df773e52c.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-bq6y92a14-livingtongues.vercel.app/birhor/entries/gallery?entries_prod%5Bquery%5D=warm%20by&entries_prod%5Btoggle%5D%5BhasImage%5D=true


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

