### PR TITLE
Fix add speaker modal

### DIFF
--- a/src/lib/components/media/SelectSpeaker.svelte
+++ b/src/lib/components/media/SelectSpeaker.svelte
@@ -7,6 +7,8 @@
     initialSpeakerId: string = undefined;
   const addSpeaker = 'AddSpeaker';
   $: speakerId = initialSpeakerId;
+  $: console.log(speakerId);
+  $: speakerId === addSpeaker ? '' : speakerId;
 
   import type { ISpeaker } from '$lib/interfaces';
   let speakers: ISpeaker[] = [];
@@ -61,7 +63,7 @@
   {#await import('$lib/components/media/AddSpeaker.svelte') then { default: AddSpeaker }}
     <AddSpeaker
       on:close={() => {
-        speakerId = null;
+        speakerId = '';
       }}
       on:newSpeaker={(event) => {
         speakerId = event.detail.id;

--- a/src/lib/components/media/SelectSpeaker.svelte
+++ b/src/lib/components/media/SelectSpeaker.svelte
@@ -61,7 +61,7 @@
   {#await import('$lib/components/media/AddSpeaker.svelte') then { default: AddSpeaker }}
     <AddSpeaker
       on:close={() => {
-        speakerId === null;
+        speakerId = null;
       }}
       on:newSpeaker={(event) => {
         speakerId = event.detail.id;


### PR DESCRIPTION
#### Relevant Issue
#118 
#### Summarize what changed in this PR (for developers)
I spoted a typo and I changed the speakerId to an empty string
#### Summarize changes in this PR (for public-facing changelog)
Modal speaker now works perfectly when you try to close it
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-95ii25n9m-livingtongues.vercel.app/bezhta/entries/list - try to add a new speaker and then close the new speaker modal


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/120"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

