### PR TITLE
fix typo

### DIFF
--- a/src/routes/[dictionaryId]/contributors.svelte
+++ b/src/routes/[dictionaryId]/contributors.svelte
@@ -87,7 +87,7 @@
             <Button
               color="red"
               size="sm"
-              on:click={() => {
+              onclick={() => {
                 if (confirm($_('misc.delete', { default: 'Delete' }))) {
                   updateOnline(`dictionaries/${dictionaryId}/invites/${invite.id}`, {
                     status: 'cancelled',


### PR DESCRIPTION
#### Relevant Issue
#122
#### Summarize what changed in this PR (for developers)
fix a typo
#### Summarize changes in this PR (for public-facing changelog)
Delete manager invitation button now is working.
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-3i63yoet2-livingtongues.vercel.app/tutelo-saponi/contributors (only works for admins)

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

