### PR TITLE
Show invitations admin panel

### DIFF
--- a/src/lib/components/admin/DisplayInvitations.svelte
+++ b/src/lib/components/admin/DisplayInvitations.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import { where } from 'firebase/firestore';
+  import { deleteDocumentOnline, updateOnline, Collection } from '$sveltefirets';
+  import type { IInvite, IHelper } from '$lib/interfaces';
+  import { isManager, admin } from '$lib/stores';
+  import Button from '$svelteui/ui/Button.svelte';
+  export let dictionaryId: string;
+  export let role: 'manager' | 'contributor' | 'writeInCollaborator';
+  let inviteType: IInvite[];
+  let helperType: IHelper[];
+</script>
+
+{#if role !== 'writeInCollaborator'}
+  <Collection
+    path={`dictionaries/${dictionaryId}/invites`}
+    queryConstraints={[where('role', '==', role), where('status', 'in', ['queued', 'sent'])]}
+    startWith={inviteType}
+    let:data={invites}>
+    {#each invites as invite}
+      <div class="py-3 flex flex-wrap items-center justify-between">
+        <div class="text-sm leading-5 font-medium text-gray-900">
+          <i
+            >{$_('contributors.invitation_sent', {
+              default: 'Invitation sent',
+            })}:</i>
+          {invite.targetEmail}
+        </div>
+        {#if $admin}
+          <Button
+            color="red"
+            size="sm"
+            onclick={() => {
+              if (confirm($_('misc.delete', { default: 'Delete' }))) {
+                updateOnline(`dictionaries/${dictionaryId}/invites/${invite.id}`, {
+                  status: 'cancelled',
+                });
+              }
+            }}
+            >{$_('misc.delete', { default: 'Delete' })}
+            <i class="fas fa-times" /><i class="fas fa-key mx-1" /></Button>
+        {/if}
+      </div>
+    {/each}
+  </Collection>
+{:else}
+  <Collection
+    path={`dictionaries/${dictionaryId}/writeInCollaborators`}
+    startWith={helperType}
+    let:data={writeInCollaborators}>
+    {#each writeInCollaborators as collaborator}
+      <div class="py-3 flex flex-wrap items-center justify-between">
+        <div class="text-sm leading-5 font-medium text-gray-900">
+          {collaborator.name}
+        </div>
+        {#if $isManager}
+          <Button
+            color="red"
+            size="sm"
+            onclick={() => {
+              if (confirm($_('misc.delete', { default: 'Delete' }))) {
+                deleteDocumentOnline(
+                  `dictionaries/${dictionaryId}/writeInCollaborators/${collaborator.id}`
+                );
+              }
+            }}
+            >{$_('misc.delete', { default: 'Delete' })}
+            <i class="fas fa-times" /></Button>
+        {/if}
+      </div>
+    {/each}
+  </Collection>
+{/if}

--- a/src/lib/components/admin/DisplayInvitations.svelte
+++ b/src/lib/components/admin/DisplayInvitations.svelte
@@ -7,6 +7,7 @@
   import Button from '$svelteui/ui/Button.svelte';
   export let dictionaryId: string;
   export let role: 'manager' | 'contributor' | 'writeInCollaborator';
+  export let adminPanel = false;
   let inviteType: IInvite[];
   let helperType: IHelper[];
 </script>
@@ -17,13 +18,23 @@
     queryConstraints={[where('role', '==', role), where('status', 'in', ['queued', 'sent'])]}
     startWith={inviteType}
     let:data={invites}>
+    {#if adminPanel && invites.length > 0}
+      <div class="text-sm font-medium text-gray-900 my-2">
+        <i
+          >{$_('contributors.invitation_sent', {
+            default: 'Invitation sent',
+          })}:</i>
+      </div>
+    {/if}
     {#each invites as invite}
-      <div class="py-3 flex flex-wrap items-center justify-between">
+      <div class={`${adminPanel ? '' : 'py-3'} flex flex-wrap items-center justify-between`}>
         <div class="text-sm leading-5 font-medium text-gray-900">
-          <i
-            >{$_('contributors.invitation_sent', {
-              default: 'Invitation sent',
-            })}:</i>
+          {#if !adminPanel}
+            <i
+              >{$_('contributors.invitation_sent', {
+                default: 'Invitation sent',
+              })}:</i>
+          {/if}
           {invite.targetEmail}
         </div>
         {#if $admin}

--- a/src/routes/[dictionaryId]/contributors.svelte
+++ b/src/routes/[dictionaryId]/contributors.svelte
@@ -12,11 +12,11 @@
 <script lang="ts">
   export let dictionaryId: string;
   import { _ } from 'svelte-i18n';
-  import { add, deleteDocumentOnline, updateOnline, Collection } from '$sveltefirets';
-  import { where } from 'firebase/firestore';
+  import { add, Collection } from '$sveltefirets';
   import { isManager, isContributor, dictionary, admin } from '$lib/stores';
   import type { IInvite, IHelper } from '$lib/interfaces';
   import Button from '$svelteui/ui/Button.svelte';
+  import DisplayInvitations from '$lib/components/admin/DisplayInvitations.svelte';
   import ShowHide from '$svelteui/functions/ShowHide.svelte';
   import { inviteHelper } from '$lib/helpers/inviteHelper';
 
@@ -69,37 +69,7 @@
     {/each}
   </Collection>
   {#if $isManager}
-    <Collection
-      path={`dictionaries/${dictionaryId}/invites`}
-      queryConstraints={[where('role', '==', 'manager'), where('status', 'in', ['queued', 'sent'])]}
-      startWith={inviteType}
-      let:data={invites}>
-      {#each invites as invite}
-        <div class="py-3 flex flex-wrap items-center justify-between">
-          <div class="text-sm leading-5 font-medium text-gray-900">
-            <i
-              >{$_('contributors.invitation_sent', {
-                default: 'Invitation sent',
-              })}:</i>
-            {invite.targetEmail}
-          </div>
-          {#if $admin}
-            <Button
-              color="red"
-              size="sm"
-              onclick={() => {
-                if (confirm($_('misc.delete', { default: 'Delete' }))) {
-                  updateOnline(`dictionaries/${dictionaryId}/invites/${invite.id}`, {
-                    status: 'cancelled',
-                  });
-                }
-              }}
-              >{$_('misc.delete', { default: 'Delete' })}
-              <i class="fas fa-times" /><i class="fas fa-key mx-1" /></Button>
-          {/if}
-        </div>
-      {/each}
-    </Collection>
+    <DisplayInvitations {dictionaryId} role="manager" />
   {/if}
 </div>
 {#if $isManager}
@@ -126,40 +96,7 @@
     {/each}
   </Collection>
   {#if $isManager}
-    <Collection
-      path={`dictionaries/${dictionaryId}/invites`}
-      queryConstraints={[
-        where('role', '==', 'contributor'),
-        where('status', 'in', ['queued', 'sent']),
-      ]}
-      startWith={inviteType}
-      let:data={invites}>
-      {#each invites as invite}
-        <div class="py-3 flex flex-wrap items-center justify-between">
-          <div class="text-sm leading-5 font-medium text-gray-900">
-            <i
-              >{$_('contributors.invitation_sent', {
-                default: 'Invitation sent',
-              })}:</i>
-            {invite.targetEmail}
-          </div>
-          {#if $admin}
-            <Button
-              color="red"
-              size="sm"
-              onclick={() => {
-                if (confirm($_('misc.delete', { default: 'Delete' }))) {
-                  updateOnline(`dictionaries/${dictionaryId}/invites/${invite.id}`, {
-                    status: 'cancelled',
-                  });
-                }
-              }}
-              >{$_('misc.delete', { default: 'Delete' })}
-              <i class="fas fa-times" /><i class="fas fa-key ml-1" /></Button>
-          {/if}
-        </div>
-      {/each}
-    </Collection>
+    <DisplayInvitations {dictionaryId} role="contributor" />
     <Button onclick={() => inviteHelper('contributor', $dictionary)} form="primary">
       <i class="far fa-envelope" />
       {$_('contributors.invite_contributors', {
@@ -184,32 +121,7 @@
   {$_('contributors.other_contributors', { default: 'Other Contributors' })}
 </h3>
 <div class="divide-y divide-gray-200">
-  <Collection
-    path={`dictionaries/${dictionaryId}/writeInCollaborators`}
-    startWith={helperType}
-    let:data={writeInCollaborators}>
-    {#each writeInCollaborators as collaborator}
-      <div class="py-3 flex flex-wrap items-center justify-between">
-        <div class="text-sm leading-5 font-medium text-gray-900">
-          {collaborator.name}
-        </div>
-        {#if $isManager}
-          <Button
-            color="red"
-            size="sm"
-            onclick={() => {
-              if (confirm($_('misc.delete', { default: 'Delete' }))) {
-                deleteDocumentOnline(
-                  `dictionaries/${dictionaryId}/writeInCollaborators/${collaborator.id}`
-                );
-              }
-            }}
-            >{$_('misc.delete', { default: 'Delete' })}
-            <i class="fas fa-times" /></Button>
-        {/if}
-      </div>
-    {/each}
-  </Collection>
+  <DisplayInvitations {dictionaryId} role="writeInCollaborator" />
 </div>
 
 <!-- <div class="text-gray-600 my-1 text-sm">

--- a/src/routes/admin/_DictionaryRow.svelte
+++ b/src/routes/admin/_DictionaryRow.svelte
@@ -9,10 +9,10 @@
   import Button from '$svelteui/ui/Button.svelte';
   import BadgeArrayEmit from '$svelteui/data/BadgeArrayEmit.svelte';
   import { createEventDispatcher } from 'svelte';
-  import { Collection, updateOnline } from '$sveltefirets';
-  import { where } from 'firebase/firestore';
+  import { Collection } from '$sveltefirets';
   import RolesManagment from './_RolesManagment.svelte';
   import IntersectionObserver from '$lib/components/ui/IntersectionObserver.svelte';
+  import DisplayInvitations from '$lib/components/admin/DisplayInvitations.svelte';
 
   const dispatch = createEventDispatcher<{
     addalternatename: string;
@@ -22,7 +22,6 @@
   }>();
 
   let helperType: IHelper[];
-  let inviteType: IInvite[];
 </script>
 
 <tr title={$admin > 1 && JSON.stringify(dictionary, null, 1)}>
@@ -53,38 +52,7 @@
           let:data={managers}>
           <RolesManagment helpers={managers} {dictionary} role="manager" />
         </Collection>
-        <Collection
-          path={`dictionaries/${dictionary.id}/invites`}
-          queryConstraints={[
-            where('role', '==', 'manager'),
-            where('status', 'in', ['queued', 'sent']),
-          ]}
-          startWith={inviteType}
-          let:data={invites}>
-          <div class="py-3 flex flex-wrap items-center justify-between">
-            <div class="text-sm leading-5 font-medium text-gray-900">
-              <i
-                >{$_('contributors.invitation_sent', {
-                  default: 'Invitation sent',
-                })}:</i>
-            </div>
-            {#each invites as invite}
-              {invite.targetEmail}
-              <Button
-                color="red"
-                size="sm"
-                onclick={() => {
-                  if (confirm($_('misc.delete', { default: 'Delete' }))) {
-                    updateOnline(`dictionaries/${dictionary.id}/invites/${invite.id}`, {
-                      status: 'cancelled',
-                    });
-                  }
-                }}
-                >{$_('misc.delete', { default: 'Delete' })}
-                <i class="fas fa-times" /><i class="fas fa-key mx-1" /></Button>
-            {/each}
-          </div>
-        </Collection>
+        <DisplayInvitations dictionaryId={dictionary.id} role="manager" adminPanel />
       {/if}
     </IntersectionObserver>
   </td>
@@ -97,6 +65,7 @@
           let:data={contributors}>
           <RolesManagment helpers={contributors} {dictionary} role="contributor" />
         </Collection>
+        <DisplayInvitations dictionaryId={dictionary.id} role="contributor" adminPanel />
       {/if}
     </IntersectionObserver>
   </td>


### PR DESCRIPTION
#### Relevant Issue
#123 
#### Summarize what changed in this PR (for developers)
I made a DisplayInvitations component to reuse it in both the contributors and the admin/dictionaries page 
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/159326545-c1dff31e-1970-4022-a59e-83319ab6e56b.png)
Admins are capable to check pending invitations and remove them whenever they want.
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-n2fo2kz1w-livingtongues.vercel.app/admin/dictionaries (only for admins)

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/125"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

