### PR TITLE
Add source table view

### DIFF
--- a/src/lib/components/table/Cell.svelte
+++ b/src/lib/components/table/Cell.svelte
@@ -5,6 +5,7 @@
   import SelectPOS from './cells/SelectPOS.svelte';
   import SelectSpeakerCell from './cells/SelectSpeakerCell.svelte';
   import AudioCell from './cells/AudioCell.svelte';
+  import BadgeArray from '$svelteui/data/BadgeArray.svelte';
   import Image from '$lib/components/image/Image.svelte';
   import { saveUpdateToFirestore } from '$lib/helpers/entry/update';
   import { dictionary } from '$lib/stores';
@@ -14,6 +15,10 @@
     canEdit = false;
 
   let updatedValue;
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher<{
+    valueupdate: { field: string; newValue: string[] }; // an array of strings for the sr field, but the valueupdate events being passed upwards are mostly strings
+  }>();
 </script>
 
 <div
@@ -44,6 +49,14 @@
       {canEdit}
       {entry}
       on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
+  {:else if column.field === 'sr'}
+    <!--TODO it doesn't work. A possible solution is to make it a child -->
+    <BadgeArray
+      strings={entry.sr || []}
+      {canEdit}
+      promptMessage={$_('entry.sr')}
+      addMessage={$_('misc.add', { default: 'Add' })}
+      on:valueupdated={(e) => dispatch('valueupdate', { field: 'sr', newValue: e.detail })} />
   {:else if column.gloss === true}
     <Textbox
       {canEdit}

--- a/src/lib/components/table/Cell.svelte
+++ b/src/lib/components/table/Cell.svelte
@@ -4,8 +4,8 @@
   import SemanticDomains from './cells/SemanticDomains.svelte';
   import SelectPOS from './cells/SelectPOS.svelte';
   import SelectSpeakerCell from './cells/SelectSpeakerCell.svelte';
+  import SelectSource from './cells/SelectSource.svelte';
   import AudioCell from './cells/AudioCell.svelte';
-  import BadgeArray from '$svelteui/data/BadgeArray.svelte';
   import Image from '$lib/components/image/Image.svelte';
   import { saveUpdateToFirestore } from '$lib/helpers/entry/update';
   import { dictionary } from '$lib/stores';
@@ -15,10 +15,6 @@
     canEdit = false;
 
   let updatedValue;
-  import { createEventDispatcher } from 'svelte';
-  const dispatch = createEventDispatcher<{
-    valueupdate: { field: string; newValue: string[] }; // an array of strings for the sr field, but the valueupdate events being passed upwards are mostly strings
-  }>();
 </script>
 
 <div
@@ -50,13 +46,10 @@
       {entry}
       on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else if column.field === 'sr'}
-    <!--TODO it doesn't work. A possible solution is to make it a child -->
-    <BadgeArray
-      strings={entry.sr || []}
+    <SelectSource
       {canEdit}
-      promptMessage={$_('entry.sr')}
-      addMessage={$_('misc.add', { default: 'Add' })}
-      on:valueupdated={(e) => dispatch('valueupdate', { field: 'sr', newValue: e.detail })} />
+      value={entry.sr}
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else if column.gloss === true}
     <Textbox
       {canEdit}

--- a/src/lib/components/table/Cell.svelte
+++ b/src/lib/components/table/Cell.svelte
@@ -6,29 +6,14 @@
   import SelectSpeakerCell from './cells/SelectSpeakerCell.svelte';
   import AudioCell from './cells/AudioCell.svelte';
   import Image from '$lib/components/image/Image.svelte';
-
+  import { saveUpdateToFirestore } from '$lib/helpers/entry/update';
+  import { dictionary } from '$lib/stores';
   import type { IColumn, IEntry } from '$lib/interfaces';
   export let column: IColumn,
     entry: IEntry,
     canEdit = false;
 
   let updatedValue;
-
-  import { dictionary } from '$lib/stores';
-  import { updateOnline } from '$sveltefirets';
-  async function saveUpdateToFirestore(e) {
-    try {
-      await updateOnline<IEntry>(
-        `dictionaries/${$dictionary.id}/words/${entry.id}`,
-        {
-          [e.detail.field]: e.detail.newValue,
-        },
-        { abbreviate: true }
-      );
-    } catch (err) {
-      alert(`${$_('misc.error', { default: 'Error' })}: ${err}`);
-    }
-  }
 </script>
 
 <div
@@ -50,9 +35,15 @@
   {:else if column.field === 'speaker'}
     <SelectSpeakerCell {canEdit} {entry} />
   {:else if column.field === 'ps'}
-    <SelectPOS {canEdit} value={entry.ps} on:valueupdate={saveUpdateToFirestore} />
+    <SelectPOS
+      {canEdit}
+      value={entry.ps}
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else if column.field === 'sdn'}
-    <SemanticDomains {canEdit} {entry} on:valueupdate={saveUpdateToFirestore} />
+    <SemanticDomains
+      {canEdit}
+      {entry}
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else if column.gloss === true}
     <Textbox
       {canEdit}
@@ -64,7 +55,7 @@
         entry._highlightResult.gl[column.field] &&
         entry._highlightResult.gl[column.field].value) ||
         ''}
-      on:valueupdate={saveUpdateToFirestore} />
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else if column.exampleSentence === true}
     <Textbox
       {canEdit}
@@ -76,7 +67,7 @@
         entry._highlightResult.xs[column.field] &&
         entry._highlightResult.xs[column.field].value) ||
         ''}
-      on:valueupdate={saveUpdateToFirestore} />
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {:else}
     <Textbox
       {canEdit}
@@ -87,6 +78,6 @@
         entry._highlightResult[column.field] &&
         entry._highlightResult[column.field].value) ||
         ''}
-      on:valueupdate={saveUpdateToFirestore} />
+      on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
   {/if}
 </div>

--- a/src/lib/components/table/ColumnAdjustSlideover.svelte
+++ b/src/lib/components/table/ColumnAdjustSlideover.svelte
@@ -92,14 +92,16 @@
                 {:else}<i class="far fa-eye" />{/if}
               </button>
             </div>
-
-            <input
-              class="w-full"
-              type="range"
-              on:input={showWidth}
-              bind:value={column.width}
-              min="31"
-              max="400" />
+            <!-- Source range input shouldn't be here because we need to show complete sources and they can be very long -->
+            {#if column.field != 'sr'}
+              <input
+                class="w-full"
+                type="range"
+                on:input={showWidth}
+                bind:value={column.width}
+                min="31"
+                max="400" />
+            {/if}
           </div>
         </div>
         {#if selectedColumn === column}

--- a/src/lib/components/table/EntriesTable.svelte
+++ b/src/lib/components/table/EntriesTable.svelte
@@ -55,7 +55,7 @@
                   class="{column.sticky ? 'sticky bg-white' : ''} h-0"
                   style="{column.sticky
                     ? 'left:' + getLeftValue(i) + 'px; --border-right-width: 3px;'
-                    : ''} --col-width: {column.width}px;">
+                    : ''} --col-width: {entry.sr ? 'auto' : `${column.width}px`};">
                   <Cell {column} {entry} canEdit={$canEdit} />
                 </td>
               {/each}
@@ -71,7 +71,7 @@
               class="{column.sticky ? 'sticky bg-white' : ''} h-0"
               style="{column.sticky
                 ? 'left:' + getLeftValue(i) + 'px; --border-right-width: 3px;'
-                : ''} --col-width: {column.width}px;">
+                : ''} --col-width: {entry.sr ? 'auto' : `${column.width}px`};">
               <Cell {column} {entry} canEdit={$canEdit} />
             </td>
           {/each}

--- a/src/lib/components/table/cells/SelectSource.svelte
+++ b/src/lib/components/table/cells/SelectSource.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import BadgeArray from '$svelteui/data/BadgeArray.svelte';
+  import { createEventDispatcher } from 'svelte';
+  export let canEdit = false,
+    value: string[];
+  const dispatch = createEventDispatcher<{
+    valueupdate: { field: string; newValue: string[] };
+  }>();
+</script>
+
+<BadgeArray
+  strings={value || []}
+  {canEdit}
+  promptMessage={$_('entry.sr')}
+  addMessage={$_('misc.add', { default: 'Add' })}
+  on:valueupdated={(e) => dispatch('valueupdate', { field: 'sr', newValue: e.detail })} />


### PR DESCRIPTION
#### Relevant Issue
#33 
#### Summarize what changed in this PR (for developers)
I added a new component to correctly display sources in the table view. I also hid the range input element on the source field because now it has a fixed width

#### Summarize changes in this PR (for public-facing changelog)
<img width="727" alt="image" src="https://user-images.githubusercontent.com/43384963/160168225-383b5d24-ae4d-441d-9da6-90ca62618b3d.png">

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-q9kuumsoy-livingtongues.vercel.app/bezhta/entries/table please edit sources to see how it works. (Only for managers)

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

