### PR TITLE
Label edit field modals table view

### DIFF
--- a/src/lib/components/table/Cell.svelte
+++ b/src/lib/components/table/Cell.svelte
@@ -15,7 +15,6 @@
     canEdit = false;
 
   let updatedValue;
-  $: console.log(column);
 </script>
 
 <div

--- a/src/lib/components/table/Cell.svelte
+++ b/src/lib/components/table/Cell.svelte
@@ -15,6 +15,7 @@
     canEdit = false;
 
   let updatedValue;
+  $: console.log(column);
 </script>
 
 <div
@@ -55,6 +56,7 @@
       {canEdit}
       field={`gl.${column.field}`}
       value={entry.gl && entry.gl[column.field]}
+      display={column.display}
       {updatedValue}
       htmlValue={(entry._highlightResult &&
         entry._highlightResult.gl &&
@@ -67,6 +69,7 @@
       {canEdit}
       field={`xs.${column.field}`}
       value={entry.xs && entry.xs[column.field]}
+      display={column.display}
       {updatedValue}
       htmlValue={(entry._highlightResult &&
         entry._highlightResult.xs &&
@@ -79,6 +82,7 @@
       {canEdit}
       field={column.field}
       value={entry[column.field]}
+      display={column.display}
       {updatedValue}
       htmlValue={(entry._highlightResult &&
         entry._highlightResult[column.field] &&

--- a/src/lib/components/table/cells/Textbox.svelte
+++ b/src/lib/components/table/cells/Textbox.svelte
@@ -4,6 +4,7 @@
     htmlValue: string,
     field: string,
     canEdit = false;
+  export let display: string;
 
   let edit = false;
 </script>
@@ -26,6 +27,7 @@
     <EditFieldModal.default
       on:valueupdate
       value={updatedValue !== undefined ? updatedValue : value}
+      {display}
       {field}
       on:close={() => {
         edit = false;

--- a/src/lib/stores/columns.ts
+++ b/src/lib/stores/columns.ts
@@ -18,6 +18,7 @@ const defaultColumns: IColumn[] = [
     field: 'lx', // lexeme
     width: 170,
     sticky: true,
+    display: 'Lexeme',
   },
   {
     field: 'soundFile',
@@ -55,6 +56,7 @@ const defaultColumns: IColumn[] = [
   {
     field: 'ph', // phonetic
     width: 170,
+    display: 'Phonetic',
   },
   {
     field: 'speaker',
@@ -63,18 +65,22 @@ const defaultColumns: IColumn[] = [
   {
     field: 'di', // dialect
     width: 130,
+    display: 'Dialect',
   },
   {
     field: 'in', // interlinearization
     width: 150,
+    display: 'Interlinearization',
   },
   {
     field: 'mr', // morphology
     width: 150,
+    display: 'Morphology',
   },
   {
     field: 'nt', // notes
     width: 300,
+    display: 'Notes',
   },
   {
     field: 'example_sentence',


### PR DESCRIPTION
#### Relevant Issue
#31 
#### Summarize what changed in this PR (for developers)
I changed the lib/stores/columns.ts in order to display names of some fields.
#### Summarize changes in this PR (for public-facing changelog)
<img width="363" alt="image" src="https://user-images.githubusercontent.com/43384963/160684261-e3d3ea68-95c4-41eb-b25e-9d7ea7c2ed2b.png">
Now you are able to see the correct label field you're editing instead of a label named edit
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-rb1qgubn8-livingtongues.vercel.app/alxa-mongolian/entries/table or go to a dictionary table view where you're a manager and try to edit some field.


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/133"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

