### PR TITLE
New entry fields

### DIFF
--- a/src/lib/interfaces/entry.interface.ts
+++ b/src/lib/interfaces/entry.interface.ts
@@ -31,6 +31,8 @@ export interface IEntry extends IFirestoreMetaDataAbbreviated, LDAlgoliaFields, 
   de?: string; // definition english, only in Bahasa Lani (jaRhn6MAZim4Blvr1iEv) deprecated by Greg
 
   // Language & entry metadata
+  nc?: string; // noun class
+  va?: string; // variant
   di?: string; // dialect for this entry
   nt?: string; // notes
   sr?: string[]; // Source(s)
@@ -38,8 +40,6 @@ export interface IEntry extends IFirestoreMetaDataAbbreviated, LDAlgoliaFields, 
   // Usage
   xv?: string; // example vernacular - used for old dictionary imports
   xs?: IExampleSentence; // example sentences - new format which allows us to bring in example sentences from multiple languages (vernacular and gloss languages)
-  va?: string; // variant
-  nc?: string; // noun class
 
   sf?: IAudio; // sound file - TODO: deprecate this and move to using array of audio files
   // sfs?: IAudio[]; // sound files

--- a/src/lib/interfaces/entry.interface.ts
+++ b/src/lib/interfaces/entry.interface.ts
@@ -38,6 +38,8 @@ export interface IEntry extends IFirestoreMetaDataAbbreviated, LDAlgoliaFields, 
   // Usage
   xv?: string; // example vernacular - used for old dictionary imports
   xs?: IExampleSentence; // example sentences - new format which allows us to bring in example sentences from multiple languages (vernacular and gloss languages)
+  va?: string; // variant
+  nc?: string; // noun class
 
   sf?: IAudio; // sound file - TODO: deprecate this and move to using array of audio files
   // sfs?: IAudio[]; // sound files

--- a/src/routes/[dictionaryId]/entry/_EntryDisplay.svelte
+++ b/src/routes/[dictionaryId]/entry/_EntryDisplay.svelte
@@ -92,7 +92,7 @@
 
     <EntrySemanticDomains {canEdit} {entry} on:valueupdate />
 
-    {#each ['mr', 'in', 'di', 'nt'] as field}
+    {#each ['nc', 'va', 'mr', 'in', 'di', 'nt'] as field}
       <EntryField
         value={entry[field]}
         {field}


### PR DESCRIPTION
#### Relevant Issue
#139 
#### Summarize what changed in this PR (for developers)
I added in entry interface and in _EntryDisplay the new entry fields
#### Summarize changes in this PR (for public-facing changelog)
<img width="230" alt="image" src="https://user-images.githubusercontent.com/43384963/162331908-302e319d-70cc-4d73-9df0-adfdba6f55f8.png">
The new entry fields are working. However we need to add the text in the translations sheet (I am not longer able to do that since I don't have permissions to edit)
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-rjg20byf8-livingtongues.vercel.app/test-diego/entry/pV4iPAblhQerqbVglYkm


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

