### PR TITLE
Reusable alternate names

### DIFF
--- a/packages/parts/src/lib/index.ts
+++ b/packages/parts/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as LatLngDisplay } from './maps/LatLngDisplay.svelte';
 
 export { default as EditableCoordinatesField } from './settings/EditableCoordinatesField.svelte';
 export { default as EditableGlossesField } from './settings/EditableGlossesField.svelte';
+export { default as EditableAlternateNames } from './settings/EditableAlternateNames.svelte';
 export { default as PublicCheckbox } from './settings/PublicCheckbox.svelte';
 
 export { glossingLanguages } from './glosses/glossing-languages';

--- a/packages/parts/src/lib/settings/EditableAlternateNames.svelte
+++ b/packages/parts/src/lib/settings/EditableAlternateNames.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import BadgeArray from 'svelte-pieces/data/BadgeArray.svelte'
+  import type { Readable } from 'svelte/store';
+  export let t: Readable<any> = undefined;
+  export let alternateNames: string[];
+
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher<{
+    update: { alternateNames: string[] };
+  }>()
+
+  async function update() {
+    dispatch('update', {
+      alternateNames
+    });
+  }
+</script>
+
+<div class="mt-6">
+  <div class="text-sm font-medium leading-5 text-gray-700 mb-1">
+    { t ? $t('create.alternate_names') : 'Alternate Names'}
+  </div>
+  <BadgeArray
+    strings={alternateNames}
+    canEdit
+    promptMessage={t ? $t('create.enter_alternate_name') : 'Enter Alternate Name'}
+    addMessage={t ? $t('misc.add') : 'Add'} />
+</div>

--- a/packages/parts/src/lib/settings/EditableAlternateNames.svelte
+++ b/packages/parts/src/lib/settings/EditableAlternateNames.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import BadgeArray from 'svelte-pieces/data/BadgeArray.svelte'
+  import BadgeArray from 'svelte-pieces/data/BadgeArray.svelte';
   import type { Readable } from 'svelte/store';
   export let t: Readable<any> = undefined;
   export let alternateNames: string[];
@@ -7,17 +7,15 @@
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher<{
     update: { alternateNames: string[] };
-  }>()
+  }>();
 </script>
 
-<div class="mt-6">
-  <div class="text-sm font-medium leading-5 text-gray-700 mb-1">
-    { t ? $t('create.alternate_names') : 'Alternate Names'}
-  </div>
-  <BadgeArray
-    strings={alternateNames}
-    canEdit
-    promptMessage={t ? $t('create.enter_alternate_name') : 'Enter Alternate Name'}
-    addMessage={t ? $t('misc.add') : 'Add'}
-    on:valueupdated={e => dispatch('update', {alternateNames: e.detail})} />
+<div class="text-sm font-medium text-gray-700 mb-1">
+  {t ? $t('create.alternate_names') : 'Alternate Names'}
 </div>
+<BadgeArray
+  strings={alternateNames}
+  canEdit
+  promptMessage={t ? $t('create.enter_alternate_name') : 'Enter Alternate Name'}
+  addMessage={t ? $t('misc.add') : 'Add'}
+  on:valueupdated={(e) => dispatch('update', { alternateNames: e.detail })} />

--- a/packages/parts/src/lib/settings/EditableAlternateNames.svelte
+++ b/packages/parts/src/lib/settings/EditableAlternateNames.svelte
@@ -8,12 +8,6 @@
   const dispatch = createEventDispatcher<{
     update: { alternateNames: string[] };
   }>()
-
-  async function update() {
-    dispatch('update', {
-      alternateNames
-    });
-  }
 </script>
 
 <div class="mt-6">
@@ -24,5 +18,6 @@
     strings={alternateNames}
     canEdit
     promptMessage={t ? $t('create.enter_alternate_name') : 'Enter Alternate Name'}
-    addMessage={t ? $t('misc.add') : 'Add'} />
+    addMessage={t ? $t('misc.add') : 'Add'}
+    on:valueupdated={e => dispatch('update', {alternateNames: e.detail})} />
 </div>

--- a/packages/parts/src/lib/settings/EditableGlossesField.svelte
+++ b/packages/parts/src/lib/settings/EditableGlossesField.svelte
@@ -31,9 +31,9 @@
   }>();
 </script>
 
-<label for="glosses" class="block text-sm font-medium text-gray-700 mb-1">
+<div class="text-sm font-medium text-gray-700 mb-1">
   {t ? $t('create.gloss_dictionary_in') : 'Make dictionary available in...'}
-</label>
+</div>
 
 <ShowHide let:show let:toggle>
   <BadgeArrayEmit

--- a/packages/parts/src/routes/2-settings/alternate-names.svx
+++ b/packages/parts/src/routes/2-settings/alternate-names.svx
@@ -4,19 +4,17 @@
   import Set from 'svelte-pieces/functions/Set.svelte';
 </script>
 
+<!-- prettier-ignore -->
 # Edit Alternate Names
 
+Listen to the `update` event when adding or removing alternate names.
+
 <Story>
-  <Set input={['Native language']} let:value={alternateNames}>
-    <EditableAlternateNames {alternateNames}  />
-  </Set>
-</Story>
-
-There's the possibility to decide what to do when adding or removing alternate names.
-
-<Story name="Handle update">
-  <Set input={['Lengua materna']} let:value={alternateNames}>
-    <EditableAlternateNames {alternateNames} 
-    on:update={e => alert(`This is the actual state of the array: ${e.detail.alternateNames}`)} />
+  <Set input={['Lengua materna']} let:value={alternateNames} let:update>
+    <EditableAlternateNames {alternateNames} on:update={(e) => update(e.detail.alternateNames)} />
+    <div>
+      Current array state:
+      <pre>{alternateNames}</pre>
+    </div>
   </Set>
 </Story>

--- a/packages/parts/src/routes/2-settings/alternate-names.svx
+++ b/packages/parts/src/routes/2-settings/alternate-names.svx
@@ -7,7 +7,16 @@
 # Edit Alternate Names
 
 <Story>
-  <Set input={['test']} let:value={alternateNames}>
+  <Set input={['Native language']} let:value={alternateNames}>
     <EditableAlternateNames {alternateNames}  />
+  </Set>
+</Story>
+
+There's the possibility to decide what to do when adding or removing alternate names.
+
+<Story name="Handle update">
+  <Set input={['Lengua materna']} let:value={alternateNames}>
+    <EditableAlternateNames {alternateNames} 
+    on:update={e => alert(`This is the actual state of the array: ${e.detail.alternateNames}`)} />
   </Set>
 </Story>

--- a/packages/parts/src/routes/2-settings/alternate-names.svx
+++ b/packages/parts/src/routes/2-settings/alternate-names.svx
@@ -13,7 +13,7 @@ Listen to the `update` event when adding or removing alternate names.
   <Set input={['Lengua materna']} let:value={alternateNames} let:update>
     <EditableAlternateNames {alternateNames} on:update={(e) => update(e.detail.alternateNames)} />
     <div>
-      Current array state:
+      Array state:
       <pre>{alternateNames}</pre>
     </div>
   </Set>

--- a/packages/parts/src/routes/2-settings/alternate-names.svx
+++ b/packages/parts/src/routes/2-settings/alternate-names.svx
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import Story from '$kitbook/stories/Story.svelte';
+  import EditableAlternateNames from '$lib/settings/EditableAlternateNames.svelte';
+  import Set from 'svelte-pieces/functions/Set.svelte';
+</script>
+
+# Edit Alternate Names
+
+<Story>
+  <Set input={['test']} let:value={alternateNames}>
+    <EditableAlternateNames {alternateNames}  />
+  </Set>
+</Story>

--- a/packages/parts/src/routes/2-settings/alternate-names.svx
+++ b/packages/parts/src/routes/2-settings/alternate-names.svx
@@ -9,12 +9,12 @@
 
 Listen to the `update` event when adding or removing alternate names.
 
-<Story>
-  <Set input={['Lengua materna']} let:value={alternateNames} let:update>
+<Set input={['Lengua materna']} let:value={alternateNames} let:update>
+  <Story>
     <EditableAlternateNames {alternateNames} on:update={(e) => update(e.detail.alternateNames)} />
-    <div>
-      Array state:
-      <pre>{alternateNames}</pre>
-    </div>
-  </Set>
-</Story>
+  </Story>
+  <div>
+    Array state:
+    <pre>{alternateNames}</pre>
+  </div>
+</Set>

--- a/packages/site/src/routes/[dictionaryId]/settings.svelte
+++ b/packages/site/src/routes/[dictionaryId]/settings.svelte
@@ -13,7 +13,7 @@
     EditableGlossesField,
     PublicCheckbox,
     glossingLanguages,
-    EditableAlternateNames
+    EditableAlternateNames,
   } from '@ld/parts';
 
   async function togglePublic(settingPublic: boolean) {
@@ -119,8 +119,9 @@
       }} />
     <div class="mb-5" />
 
-    <EditableAlternateNames 
-      alternateNames={dictionary.alternateNames} 
+    <EditableAlternateNames
+      {t}
+      alternateNames={dictionary.alternateNames}
       on:update={(e) => {
         update(`dictionaries/${dictionary.id}`, {
           alternateNames: e.detail.alternateNames,
@@ -149,7 +150,7 @@
     <div class="mb-5" />
 
     <ShowHide let:show let:toggle>
-      <Button onclick={toggle} class=mb-5>
+      <Button onclick={toggle} class="mb-5">
         {$t('settings.optional_data_fields', { default: 'Optional Data Fields' })}:
         {$t('header.contact_us', { default: 'Contact Us' })}
       </Button>

--- a/packages/site/src/routes/[dictionaryId]/settings.svelte
+++ b/packages/site/src/routes/[dictionaryId]/settings.svelte
@@ -13,6 +13,7 @@
     EditableGlossesField,
     PublicCheckbox,
     glossingLanguages,
+    EditableAlternateNames
   } from '@ld/parts';
 
   async function togglePublic(settingPublic: boolean) {
@@ -115,6 +116,15 @@
         } else {
           alert(t ? $t('header.contact_us') : 'Contact Us');
         }
+      }} />
+    <div class="mb-5" />
+
+    <EditableAlternateNames 
+      alternateNames={dictionary.alternateNames} 
+      on:update={(e) => {
+        update(`dictionaries/${dictionary.id}`, {
+          alternateNames: e.detail.alternateNames,
+        });
       }} />
     <div class="mb-5" />
 

--- a/packages/site/src/routes/create-dictionary.svelte
+++ b/packages/site/src/routes/create-dictionary.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import BadgeArray from 'svelte-pieces/data/BadgeArray.svelte';
   import { user } from '$lib/stores';
   import Header from '$lib/components/shell/Header.svelte';
   import Button from 'svelte-pieces/ui/Button.svelte';
@@ -207,18 +206,6 @@
         }} />
     </div>
 
-    <div class="mt-6">
-      <div class="text-sm font-medium leading-5 text-gray-700 mb-1">
-        {$t('create.alternate_names', { default: 'Alternate Names' })}
-      </div>
-      <BadgeArray
-        bind:strings={alternateNames}
-        canEdit
-        promptMessage={$t('create.enter_alternate_name', {
-          default: 'Enter Alternate Name',
-        })}
-        addMessage={$t('misc.add', { default: 'Add' })} />
-    </div>
     <div class="mt-6 flex">
       <div class="w-1/2">
         <label for="isocode" class="block text-sm font-medium leading-5 text-gray-700">

--- a/packages/site/src/routes/create-dictionary.svelte
+++ b/packages/site/src/routes/create-dictionary.svelte
@@ -193,9 +193,11 @@
     <!-- not used in web app presently -->
     <!-- placeholder={$t('create.languages', { default: 'Language(s)' })} -->
 
+    <div class="mt-6" />
     <EditableAlternateNames
+      {t}
       {alternateNames}
-      on:update={((e) => alternateNames = e.detail.alternateNames)} />
+      on:update={(e) => (alternateNames = e.detail.alternateNames)} />
 
     <div class="mt-6">
       <EditableCoordinatesField

--- a/packages/site/src/routes/create-dictionary.svelte
+++ b/packages/site/src/routes/create-dictionary.svelte
@@ -11,7 +11,7 @@
   import {
     EditableCoordinatesField,
     EditableGlossesField,
-    PublicCheckbox,
+    EditableAlternateNames,
     glossingLanguages,
   } from '@ld/parts';
 
@@ -192,6 +192,10 @@
       }} />
     <!-- not used in web app presently -->
     <!-- placeholder={$t('create.languages', { default: 'Language(s)' })} -->
+
+    <EditableAlternateNames
+      {alternateNames}
+      on:update={((e) => alternateNames = e.detail.alternateNames)} />
 
     <div class="mt-6">
       <EditableCoordinatesField


### PR DESCRIPTION
#### Relevant Issue
#129 
#### Summarize what changed in this PR (for developers)
Adding a reusable component to Kitbook, settings and create-dictionary pages
#### Summarize changes in this PR (for public-facing changelog)
N/A
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).

http://localhost:3042/2-settings/alternate-names
https://ld-parts-git-reusable-alternate-names-livingtongues.vercel.app/2-settings/alternate-names
http://localhost:3041/create-dictionary
http://localhost:3041/diego-language/settings
https://living-dictionaries-git-reusable-alternate-names-livingtongues.vercel.app/create-dictionary
https://living-dictionaries-git-reusable-alternate-names-livingtongues.vercel.app/diego-language/settings

<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/156"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

