### PR TITLE
add new speaker dynamic info

### DIFF
--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -62,10 +62,16 @@
   </select>
 </div>
 
-<div class="mb-4">
-  <p><b>Birthplace:</b> {currentSpeaker?.birthplace.charAt(0).toUpperCase() + currentSpeaker?.birthplace.slice(1)}</p>
-  <p><b>Gender:</b> {currentSpeaker?.gender == 'f' ? 'Female' : 'Male'}</p>
-</div>
+{#if currentSpeaker?.birthplace || currentSpeaker?.gender}
+  <div class="mb-4">
+    {#if currentSpeaker.birthplace}
+      <p><b>Birthplace:</b> {currentSpeaker.birthplace.charAt(0).toUpperCase() + currentSpeaker.birthplace.slice(1)}</p>
+    {/if}
+    {#if currentSpeaker.gender}
+      <p><b>Gender:</b> {currentSpeaker.gender == 'f' ? 'Female' : currentSpeaker.gender == 'm' ? 'Male' : 'Other'}</p>
+    {/if}
+  </div>
+{/if}
 
 {#if speakerId === addSpeaker}
   {#await import('$lib/components/media/AddSpeaker.svelte') then { default: AddSpeaker }}

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -31,7 +31,7 @@
   </div>
 {/if}
 
-<div class="flex rounded-md shadow-sm mb-1">
+<div class="flex rounded-md shadow-sm mb-2">
   <label
     for="speaker"
     class="inline-flex items-center px-3 ltr:rounded-l-md rtl:rounded-r-md border
@@ -62,10 +62,9 @@
   </select>
 </div>
 
-<div class="flex justify-between mb-4">
+<div class="mb-4">
   <p><b>Birthplace:</b> {currentSpeaker?.birthplace.charAt(0).toUpperCase() + currentSpeaker?.birthplace.slice(1)}</p>
   <p><b>Gender:</b> {currentSpeaker?.gender == 'f' ? 'Female' : 'Male'}</p>
-  <p><b>Decade:</b> {currentSpeaker?.decade}</p>
 </div>
 
 {#if speakerId === addSpeaker}

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -7,6 +7,7 @@
     initialSpeakerId: string = undefined;
   const addSpeaker = 'AddSpeaker';
   $: speakerId = initialSpeakerId;
+  let currentSpeaker: ISpeaker;
 
   import type { ISpeaker } from '@ld/types';
   let speakers: ISpeaker[] = [];
@@ -18,7 +19,10 @@
 <Collection
   path="speakers"
   startWith={speakers}
-  on:data={(e) => (speakers = e.detail.data)}
+  on:data={(e) => {
+    speakers = e.detail.data; 
+    currentSpeaker = speakers.find((e) => e.id == speakerId);
+  }}
   queryConstraints={[where('contributingTo', 'array-contains', dictionaryId)]} />
 
 {#if !speakerId}
@@ -27,7 +31,7 @@
   </div>
 {/if}
 
-<div class="flex rounded-md shadow-sm mb-4">
+<div class="flex rounded-md shadow-sm mb-1">
   <label
     for="speaker"
     class="inline-flex items-center px-3 ltr:rounded-l-md rtl:rounded-r-md border
@@ -41,6 +45,7 @@
       if (speakerId && speakerId !== addSpeaker) {
         dispatch('update', { speakerId });
       }
+      currentSpeaker = speakers.find((e) => e.id == speakerId);
     }}
     id="speaker"
     class="block w-full pl-3 !rounded-none ltr:!rounded-r-md rtl:!rounded-l-md form-input">
@@ -55,6 +60,12 @@
       {$_('misc.add', { default: 'Add' })}
     </option>
   </select>
+</div>
+
+<div class="flex justify-between mb-4">
+  <p><b>Birthplace:</b> {currentSpeaker?.birthplace.charAt(0).toUpperCase() + currentSpeaker?.birthplace.slice(1)}</p>
+  <p><b>Gender:</b> {currentSpeaker?.gender == 'f' ? 'Female' : 'Male'}</p>
+  <p><b>Decade:</b> {currentSpeaker?.decade}</p>
 </div>
 
 {#if speakerId === addSpeaker}


### PR DESCRIPTION
#### Relevant Issue
#157 
#### Summarize what changed in this PR (for developers)
Add new metada of speakers in SelectSpeaker modal
#### Summarize changes in this PR (for public-facing changelog)

![image](https://user-images.githubusercontent.com/43384963/167203165-8819b260-bb4b-4668-a223-c23f332f0ff3.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
http://localhost:3041/bezhta/entries/list (as admin)
https://living-dictionaries-git-metadata-for-speakers-livingtongues.vercel.app/bezhta/entries/list (as admin)


<a href="https://gitpod.io/#https://github.com/livingtongues/living-dictionaries/pull/159"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

