### PR TITLE
Change delete media button design

### DIFF
--- a/packages/site/src/lib/components/image/Image.svelte
+++ b/packages/site/src/lib/components/image/Image.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n';
   import type { IEntry } from '@living-dictionaries/types';
+  import DeleteButton from '../media/DeleteButton.svelte';
   export let entry: IEntry,
     canEdit = false,
     square: number = undefined,
@@ -72,17 +73,7 @@
       </div>
       <img class="object-contain max-h-full" alt="Image of {entry.lx}" {src} />
       {#if canEdit}
-        <div
-          class="font-semibold text-red-500 p-4 flex justify-between
-            items-center absolute bottom-0 inset-x-0 bg-opacity-25 bg-black">
-          <button
-            type="button"
-            on:click|stopPropagation={() => deleteImage(entry)}
-            class="ml-auto px-3 py-2">
-            <i class="far fa-trash-alt" />
-            {$_('misc.delete', { default: 'Delete' })}
-          </button>
-        </div>
+        <DeleteButton action={() => deleteImage(entry)} />
       {/if}
     </div>
   </div>

--- a/packages/site/src/lib/components/media/DeleteButton.svelte
+++ b/packages/site/src/lib/components/media/DeleteButton.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  export let action = () => {}
+</script>
+
+<div
+  class="font-semibold text-white py-2 px-1 flex justify-end">
+  <button
+    type="button"
+    on:click|stopPropagation={action}
+    class="px-3 py-2 rounded bg-red-500 transition-all hover:bg-red-600 transform hover:scale-105">
+    <i class="far fa-trash-alt" />
+    {$_('misc.delete', { default: 'Delete' })}
+  </button>
+</div>

--- a/packages/site/src/lib/components/video/PlayVideo.svelte
+++ b/packages/site/src/lib/components/video/PlayVideo.svelte
@@ -5,6 +5,7 @@
   import VideoIFrame from './VideoIFrame.svelte';
   // import { crossfade, scale } from 'svelte/transition';
   import { deleteVideo } from '$lib/helpers/delete';
+  import DeleteButton from '../media/DeleteButton.svelte';
 
   export let entry: IEntry,
     video: IVideo,
@@ -41,16 +42,7 @@
     {/if}
     <!-- <img class="object-contain max-h-full" alt="Image of {entry.lx}" {src} /> -->
     {#if canEdit}
-      <div
-        class="font-semibold text-white py-2 px-1 flex justify-end">
-        <button
-          type="button"
-          on:click|stopPropagation={() => deleteVideo(entry, video)}
-          class="px-3 py-2 rounded bg-red-500 transition-all hover:bg-red-600 transform hover:scale-105">
-          <i class="far fa-trash-alt" />
-          {$_('misc.delete', { default: 'Delete' })}
-        </button>
-      </div>
+      <DeleteButton action={() => deleteVideo(entry, video)} />
     {/if}
   </div>
 </div>

--- a/packages/site/src/lib/components/video/PlayVideo.svelte
+++ b/packages/site/src/lib/components/video/PlayVideo.svelte
@@ -42,12 +42,11 @@
     <!-- <img class="object-contain max-h-full" alt="Image of {entry.lx}" {src} /> -->
     {#if canEdit}
       <div
-        class="font-semibold text-red-500 p-4 flex justify-between
-            items-center absolute bottom-0 inset-x-0 bg-opacity-25 bg-black">
+        class="font-semibold text-white py-2 px-1 flex justify-end">
         <button
           type="button"
           on:click|stopPropagation={() => deleteVideo(entry, video)}
-          class="ml-auto px-3 py-2">
+          class="px-3 py-2 rounded bg-red-500 transition-all hover:bg-red-600 transform hover:scale-105">
           <i class="far fa-trash-alt" />
           {$_('misc.delete', { default: 'Delete' })}
         </button>


### PR DESCRIPTION
#### Relevant Issue
#171 
#### Summarize what changed in this PR (for developers)
I made a reusable button for deleting media, I also changed the position and the style of the button. Everything was done with tailwind. This button is used in the PlayVideo and Image components 
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/170770685-26c801cb-1910-47aa-9002-cc1c3d4a1954.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-radx0ux7r-livingtongues.vercel.app/bezhta/entries/list
http://localhost:3041/bezhta/entries/list
