### PR TITLE
Modify notes field modal

### DIFF
--- a/packages/site/src/lib/components/editor/CKEditor.svelte
+++ b/packages/site/src/lib/components/editor/CKEditor.svelte
@@ -38,3 +38,16 @@
 <div class="tw-prose">
   <div bind:this={editorElement} contenteditable bind:innerHTML={value} />
 </div>
+
+<style global>
+  /*Textbox*/
+  .ck-editor__editable {
+      min-height: 800px;
+      max-height: 800px;
+      min-width: 860px;
+  }
+  /*Toolbar*/
+  .ck-editor__top {
+      min-width: 860px;
+  }
+</style>

--- a/packages/site/src/lib/components/editor/CKEditor.svelte
+++ b/packages/site/src/lib/components/editor/CKEditor.svelte
@@ -35,19 +35,21 @@
   });
 </script>
 
-<div class="tw-prose">
+<div class="tw-prose inherit">
   <div bind:this={editorElement} contenteditable bind:innerHTML={value} />
 </div>
 
-<style global>
-  /*Textbox*/
-  .ck-editor__editable {
-      min-height: 800px;
-      max-height: 800px;
-      min-width: 860px;
+<style>
+  :global(.ck-editor__editable) {
+    min-height: inherit;
   }
-  /*Toolbar*/
-  .ck-editor__top {
-      min-width: 860px;
+  :global(.ck-editor__main) {
+    min-height: inherit;
+  }
+  :global(.ck-editor) {
+    min-height: inherit;
+  }
+  .inherit {
+    min-height: inherit;
   }
 </style>

--- a/packages/site/src/lib/components/modals/EditFieldModal.svelte
+++ b/packages/site/src/lib/components/modals/EditFieldModal.svelte
@@ -117,11 +117,11 @@
   }
 </script>
 
-<Modal on:close>
+<Modal heritableSize={field === 'nt' ? true : false} on:close>
   <span slot="heading">{display}</span>
-  <form on:submit|preventDefault={save}>
-    <div>
-      <div class="rounded-md shadow-sm">
+  <form class="inherit" on:submit|preventDefault={save}>
+    <div class="inherit">
+      <div class="rounded-md shadow-sm inherit">
         {#if field === 'nt'}
           {#await import('$lib/components/editor/ClassicCustomized.svelte') then { default: ClassicCustomized }}
             <ClassicCustomized {editorConfig} bind:html={value} />
@@ -155,7 +155,7 @@
             onclick={() => (value = italicizeSelection(inputEl))}
             ><i>Italicize</i> selection</Button>
           {#if value.indexOf('<i>') > -1}
-            <div class="tw-prose mt-2 p-1 shadow bg-gray-200">
+            <div class="tw-prose mt-2 p-1 shadow bg-gray-200 inherit">
               {@html value}
             </div>
           {/if}
@@ -181,3 +181,9 @@
     </div>
   </form>
 </Modal>
+
+<style>
+  .inherit {
+    min-height: inherit;
+  }
+</style>

--- a/packages/site/src/lib/components/modals/EditFieldModal.svelte
+++ b/packages/site/src/lib/components/modals/EditFieldModal.svelte
@@ -155,7 +155,7 @@
             onclick={() => (value = italicizeSelection(inputEl))}
             ><i>Italicize</i> selection</Button>
           {#if value.indexOf('<i>') > -1}
-            <div class="tw-prose mt-2 p-1 shadow bg-gray-200 inherit">
+            <div class="tw-prose mt-2 p-1 shadow bg-gray-200">
               {@html value}
             </div>
           {/if}

--- a/packages/site/src/lib/components/ui/Modal.svelte
+++ b/packages/site/src/lib/components/ui/Modal.svelte
@@ -97,7 +97,7 @@
     @apply bg-gray-100 px-4 py-3 sm:px-6 flex flex-wrap justify-end;
   }
   .heritable-size {
-    min-height: 350px
+    min-height: 25vw;
   }
   .inherit {
     min-height: inherit;

--- a/packages/site/src/lib/components/ui/Modal.svelte
+++ b/packages/site/src/lib/components/ui/Modal.svelte
@@ -55,6 +55,7 @@
   </div>
 
   <div
+    style="width:700px; height:600px"
     transition:fade={{ duration: 200 }}
     class="{$$props.class} bg-white rounded-lg overflow-hidden shadow-xl transform
     transition-all sm:max-w-lg w-full max-h-full flex flex-col"

--- a/packages/site/src/lib/components/ui/Modal.svelte
+++ b/packages/site/src/lib/components/ui/Modal.svelte
@@ -2,6 +2,7 @@
   import { portal } from 'svelte-pieces/actions/portal';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { fade } from 'svelte/transition';
+  export let heritableSize = false
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch('close');
@@ -55,15 +56,14 @@
   </div>
 
   <div
-    style="width:700px; height:600px"
     transition:fade={{ duration: 200 }}
     class="{$$props.class} bg-white rounded-lg overflow-hidden shadow-xl transform
-    transition-all sm:max-w-lg w-full max-h-full flex flex-col"
+    transition-all sm:max-w-lg w-full max-h-full flex flex-col {heritableSize ? 'heritable-size' : ''}"
     role="dialog"
     aria-modal="true"
     aria-labelledby="modal-headline"
     bind:this={modal}>
-    <div class="p-4 sm:p-6 overflow-y-auto flex-1">
+    <div class="p-4 sm:p-6 overflow-y-auto flex-1 inherit">
       <div class="flex mb-4 sm:mb-6">
         <h3 class="text-lg leading-6 font-medium text-gray-900 flex-grow" id="modal-headline">
           <slot name="heading" />
@@ -83,7 +83,7 @@
           </svg>
         </button>
       </div>
-      <div class="mt-2">
+      <div class="mt-2 inherit">
         <slot />
       </div>
     </div>
@@ -95,5 +95,11 @@
   :global(.modal-footer) {
     @apply -m-4 sm:-m-6 mt-4 sm:mt-6;
     @apply bg-gray-100 px-4 py-3 sm:px-6 flex flex-wrap justify-end;
+  }
+  .heritable-size {
+    min-height: 350px
+  }
+  .inherit {
+    min-height: inherit;
   }
 </style>


### PR DESCRIPTION
#### Relevant Issue
#190 
#### Summarize what changed in this PR (for developers)
I added a new prop (heritableSize) to the Modal component in oder to be able to change its size. I also had to add the inherit value to the min-height property to all of the children elements in order to modify the outer ck-editor HTML elements.
#### Summarize changes in this PR (for public-facing changelog)
we have a higher modal for notes:
![image](https://user-images.githubusercontent.com/43384963/175116317-74a9a54a-4945-4d57-b753-5194638b4736.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
http://localhost:3041/akateko/entry/tChfJAqRIuNGdO8dnDrn
https://living-dictionaries-esieydbcw-livingtongues.vercel.app/akateko/entry/tChfJAqRIuNGdO8dnDrn
(You should be a manager to be able to open the notes field modal)