### PR TITLE
improve select speaker modal for users

### DIFF
--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -14,7 +14,6 @@
 
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher<{ update: { speakerId: string } }>();
-  //let focus = true;
   onMount(() => {
     const speakerElement = document.getElementById("speaker");
     if (!speakerId) {

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -76,6 +76,7 @@
 <slot {speakerId} />
 
 <style>
+  /*I'm doing this because it seems unocss doesn't have this class. Right now some parent element has an appearance:none style*/
   #speaker {
     appearance: auto;
   }

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -85,7 +85,7 @@
   /*This is only for Mozilla browser*/
   @media all and (min--moz-device-pixel-ratio:0) {
   #speaker:hover{
-    outline-style: solid;
+    outline: 1px solid #3088fa;
   }
 }  
 </style>

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -15,10 +15,7 @@
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher<{ update: { speakerId: string } }>();
   onMount(() => {
-    const speakerElement = document.getElementById("speaker");
-    if (!speakerId) {
-      speakerElement.focus()
-    }
+    document.getElementById("speaker").focus();
   })
 </script>
 
@@ -62,14 +59,6 @@
       {$_('misc.add', { default: 'Add' })}
     </option>
   </select>
-  <svg
-    class="dropdown-arrow absolute right-6 gray-color"
-    xmlns="http://www.w3.org/2000/svg"
-    width="18"
-    height="18"
-    viewBox="0 0 18 18">
-    <path d="M5 8l4 4 4-4z" />
-  </svg>
 </div>
 
 {#if speakerId === addSpeaker}
@@ -87,7 +76,16 @@
 <slot {speakerId} />
 
 <style>
-  .gray-color {
-    filter: invert(50%);
+  #speaker {
+    appearance: auto;
   }
+  #speaker:hover {
+    outline-color: blue;
+  }
+  /*This is only for Mozilla browser*/
+  @media all and (min--moz-device-pixel-ratio:0) {
+  #speaker:hover{
+    outline-style: solid;
+  }
+}  
 </style>

--- a/packages/site/src/lib/components/media/SelectSpeaker.svelte
+++ b/packages/site/src/lib/components/media/SelectSpeaker.svelte
@@ -2,6 +2,7 @@
   import { _ } from 'svelte-i18n';
   import { Collection } from 'sveltefirets';
   import { where } from 'firebase/firestore';
+  import { onMount } from 'svelte'
 
   export let dictionaryId: string,
     initialSpeakerId: string = undefined;
@@ -13,6 +14,13 @@
 
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher<{ update: { speakerId: string } }>();
+  //let focus = true;
+  onMount(() => {
+    const speakerElement = document.getElementById("speaker");
+    if (!speakerId) {
+      speakerElement.focus()
+    }
+  })
 </script>
 
 <Collection
@@ -55,6 +63,14 @@
       {$_('misc.add', { default: 'Add' })}
     </option>
   </select>
+  <svg
+    class="dropdown-arrow absolute right-6 gray-color"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 18 18">
+    <path d="M5 8l4 4 4-4z" />
+  </svg>
 </div>
 
 {#if speakerId === addSpeaker}
@@ -70,3 +86,9 @@
 {/if}
 
 <slot {speakerId} />
+
+<style>
+  .gray-color {
+    filter: invert(50%);
+  }
+</style>


### PR DESCRIPTION
#### Relevant Issue
#219 
#### Summarize what changed in this PR (for developers)
I changed the select HTML element appearance to auto and added a different outline color when hovering l I'm also making the select HTML tag to focus every time the modal appears. I also tested on the four main browsers and I had to do something different for Firefox since it handles the focus thing way different.
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/197265464-fc7c344b-5fbb-4f64-b5b9-e95b2cf5c1cc.png)
When hovering on it:
![image](https://user-images.githubusercontent.com/43384963/197265550-46a92e38-38c9-4d50-9b1f-3c6d046c3d71.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
Click on audio or video buttons as manager or admin:
https://living-dictionaries-38kbsq0e6-livingtongues.vercel.app//bezhta/entries/list
http://localhost:3041/bezhta/entries/list
