### PR TITLE
hide Itonama phonetics and local orthography from entry list view

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/_ListEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/_ListEntry.svelte
@@ -36,11 +36,11 @@
     class="p-2 text-lg flex-grow flex flex-col justify-between hover:bg-gray-200 ">
     <div>
       <span class="font-semibold text-gray-900 mr-1">{entry.lx}</span>
-      {#if entry.ph}
+      {#if entry.ph && $dictionary.id != 'itonama'}
         <span class="mr-1 hidden sm:inline">[{entry.ph}]</span>
       {/if}
 
-      {#if entry.lo}<i class="mr-1">{entry.lo}</i>{/if}
+      {#if entry.lo && $dictionary.id != 'itonama'}<i class="mr-1">{entry.lo}</i>{/if}
       {#if entry.lo2}<i class="mr-1" class:sompeng={$page.params.dictionaryId === 'sora'}
           >{entry.lo2}</i
         >{/if}


### PR DESCRIPTION
#### Relevant Issue
N/A
#### Summarize what changed in this PR (for developers)
N/A
#### Summarize changes in this PR (for public-facing changelog)
Hiding Itonama phonetics and local orthography fields from list entry view by community request
#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
