### PR TITLE
send glossing languages to edit field modal

### DIFF
--- a/packages/parts/src/lib/entries/EditField.svelte
+++ b/packages/parts/src/lib/entries/EditField.svelte
@@ -18,7 +18,10 @@
   export let adding = false;
 
   const glosses:string[] = getContext('glosses');
-  const filteredGlosses = glosses.map(bcp => glossingLanguages[bcp]);
+  let filteredGlosses = {};
+  glosses.forEach(bcp => {
+    filteredGlosses[bcp] = glossingLanguages[bcp];
+  });
 
   function close() {
     dispatch('close');
@@ -106,6 +109,7 @@
   };
 
   let inputEl: HTMLInputElement;
+  let bcp:string;
 
   function smallCapsSelection(el: HTMLInputElement) {
     const { selectionStart, selectionEnd } = el;
@@ -144,6 +148,26 @@
             class="form-input block w-full pr-9" />
         </InputWrapper>
       </Keyman>
+    {:else if field === 'lx'}
+    {#each Object.keys(filteredGlosses) as language}
+      {#if filteredGlosses[language].showKeyboard}
+      <Button form="menu" size="sm" onclick={() => {bcp = language}} active={language === bcp}
+        >{filteredGlosses[language].vernacularName} ({language})</Button>
+      {/if}
+    {/each}
+    <Keyman>
+      <InputWrapper fixed {bcp}>
+        <input
+          bind:this={inputEl}
+          dir="ltr"
+          type="text"
+          required={field === 'lx'}
+          use:autofocus
+          bind:value
+          class:sompeng={display === 'Sompeng-Mardir'}
+          class="form-input block w-full pr-9" />
+      </InputWrapper>
+    </Keyman>
     {:else}
       <input
         bind:this={inputEl}

--- a/packages/parts/src/lib/entries/EditField.svelte
+++ b/packages/parts/src/lib/entries/EditField.svelte
@@ -2,7 +2,7 @@
   import type { Readable } from 'svelte/store';
   export let t: Readable<any> = undefined;
 
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, getContext } from 'svelte';
   import Button from 'svelte-pieces/ui/Button.svelte';
   import Keyman from './keyboards/keyman/Keyman.svelte';
   import InputWrapper from './keyboards/keyman/InputWrapper.svelte';
@@ -15,6 +15,8 @@
   export let field: string;
   export let display: string = undefined; // used only for Sompeng-Mardir now that Modal is separate
   export let adding = false;
+
+  const glosses:string[] = getContext('glosses');
 
   function close() {
     dispatch('close');

--- a/packages/parts/src/lib/entries/EditField.svelte
+++ b/packages/parts/src/lib/entries/EditField.svelte
@@ -3,6 +3,7 @@
   export let t: Readable<any> = undefined;
 
   import { createEventDispatcher, getContext } from 'svelte';
+  import { glossingLanguages } from '../glosses/glossing-languages';
   import Button from 'svelte-pieces/ui/Button.svelte';
   import Keyman from './keyboards/keyman/Keyman.svelte';
   import InputWrapper from './keyboards/keyman/InputWrapper.svelte';
@@ -17,6 +18,7 @@
   export let adding = false;
 
   const glosses:string[] = getContext('glosses');
+  const filteredGlosses = glosses.map(bcp => glossingLanguages[bcp]);
 
   function close() {
     dispatch('close');

--- a/packages/parts/src/lib/entries/EditField.svelte
+++ b/packages/parts/src/lib/entries/EditField.svelte
@@ -148,26 +148,26 @@
             class="form-input block w-full pr-9" />
         </InputWrapper>
       </Keyman>
-    {:else if field === 'lx'}
-    {#each Object.keys(filteredGlosses) as language}
-      {#if filteredGlosses[language].showKeyboard}
-      <Button form="menu" size="sm" onclick={() => {bcp = language}} active={language === bcp}
-        >{filteredGlosses[language].vernacularName} ({language})</Button>
-      {/if}
-    {/each}
-    <Keyman>
-      <InputWrapper fixed {bcp}>
-        <input
-          bind:this={inputEl}
-          dir="ltr"
-          type="text"
-          required={field === 'lx'}
-          use:autofocus
-          bind:value
-          class:sompeng={display === 'Sompeng-Mardir'}
-          class="form-input block w-full pr-9" />
-      </InputWrapper>
-    </Keyman>
+    {:else if field.startsWith('lo') || field === 'lx'}
+      {#each Object.keys(filteredGlosses) as language}
+        {#if filteredGlosses[language].showKeyboard}
+        <Button form="menu" size="sm" onclick={() => {bcp = language}} active={language === bcp}
+          >{filteredGlosses[language].vernacularName} ({language})</Button>
+        {/if}
+      {/each}
+      <Keyman>
+        <InputWrapper fixed {bcp}>
+          <input
+            bind:this={inputEl}
+            dir="ltr"
+            type="text"
+            required={field === 'lx'}
+            use:autofocus
+            bind:value
+            class:sompeng={display === 'Sompeng-Mardir'}
+            class="form-input block w-full pr-9" />
+        </InputWrapper>
+      </Keyman>
     {:else}
       <input
         bind:this={inputEl}

--- a/packages/parts/src/routes/0-entries/1-keyboards/keyman/+page.svx
+++ b/packages/parts/src/routes/0-entries/1-keyboards/keyman/+page.svx
@@ -9,6 +9,7 @@
 
   let value = '';
   let paragraph = '';
+  console.log(glossingLanguages)
 </script>
 
 <!-- prettier-ignore -->

--- a/packages/parts/src/routes/0-entries/1-keyboards/keyman/+page.svx
+++ b/packages/parts/src/routes/0-entries/1-keyboards/keyman/+page.svx
@@ -9,7 +9,6 @@
 
   let value = '';
   let paragraph = '';
-  console.log(glossingLanguages)
 </script>
 
 <!-- prettier-ignore -->

--- a/packages/site/src/routes/[dictionaryId]/entry/EntryDisplay.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/EntryDisplay.svelte
@@ -7,12 +7,15 @@
   import BadgeArray from 'svelte-pieces/data/BadgeArray.svelte';
   import EntryMedia from './EntryMedia.svelte';
   import { dictionary } from '$lib/stores';
+  import { setContext } from 'svelte';
 
   export let entry: IEntry,
     videoAccess = false,
     canEdit = false,
     alternateOrthographies = [],
     glossingLanguages = ['en'];
+
+  setContext<string[]>('glosses', glossingLanguages);
 
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher<{
@@ -39,6 +42,7 @@
 
   <div class="md:w-2/3 flex flex-col">
     <div class="hidden md:block">
+      <!-- TODO add glossing languages -->
       <EntryField
         {t}
         value={entry.lx}

--- a/packages/site/src/routes/[dictionaryId]/entry/EntryDisplay.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/EntryDisplay.svelte
@@ -42,7 +42,6 @@
 
   <div class="md:w-2/3 flex flex-col">
     <div class="hidden md:block">
-      <!-- TODO add glossing languages -->
       <EntryField
         {t}
         value={entry.lx}


### PR DESCRIPTION
#### Relevant Issue
#40 
#### Summarize what changed in this PR (for developers)
I added buttons to lexeme and local orthographies fields in order to select a keyboard from glossing languages available in the dictionary
#### Summarize changes in this PR (for public-facing changelog)
![image](https://user-images.githubusercontent.com/43384963/202050341-15590fda-fc7d-4ae9-b4b2-1d8f8aebaad0.png)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-il4u71cyw-livingtongues.vercel.app/birhor/entry/sLHxFt3IQI1jEleS0aYc
localhost:3041/birhor/entry/sLHxFt3IQI1jEleS0aYc