### PR TITLE
add anchor tag to card element

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/GalleryEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/GalleryEntry.svelte
@@ -19,41 +19,18 @@
         {canEdit}
         on:delete={() => deleteImage(entry)} />
     </div>
-    <a data-sveltekit-prefetch href={entry.id}>
-      <div class="card-content-wrapper">
-        <p class="font-semibold absolute top-0 left-0">
-          {@html entry._highlightResult ? entry._highlightResult?.lx?.value : entry.lx}
-        </p>
+    <a href={entry.id} style="background: #f3f3f3;" class="block p-[10px]">
+      <div class="font-semibold">
+        {@html entry._highlightResult?.lx?.value || entry.lx}
+      </div>
+      <div class="text-xs">
         <!--Simple solution until we really work on implementing this feature-->
         {#if $dictionary.id === 'iquito' || $dictionary.id === 'muniche'}
-          <p class="absolute bottom-0 left-0 text-xs">
-            {@html entry._highlightResult
-              ? entry._highlightResult?.gl?.es?.value
-              : entry.gl && entry.gl.es
-              ? entry.gl.es
-              : ''}
-          </p>
+          {@html entry._highlightResult?.gl?.es?.value || entry.gl?.es || ''}
         {:else}
-          <p class="absolute bottom-0 left-0 text-xs">
-            {@html entry._highlightResult
-              ? entry._highlightResult?.gl?.en?.value
-              : entry.gl && entry.gl.en
-              ? entry.gl.en
-              : ''}
-          </p>
+          {@html entry._highlightResult?.gl?.en?.value || entry.gl?.en || ''}
         {/if}
       </div>
     </a>
   </div>
 </div>
-
-<style>
-  .card-content-wrapper {
-    background: #f3f3f3;
-    padding: 10px;
-  }
-
-  .card-content-wrapper > p {
-    position: relative;
-  }
-</style>


### PR DESCRIPTION
#### Relevant Issue
#254 
#### Summarize what changed in this PR (for developers)
Add an anchor tag on Gallery view cards to link them to their corresponding entry view. 
#### Summarize changes in this PR (for public-facing changelog)

#### How can the changes be tested? Please also provide applicable links using preview deployments once they are available (will require editing this message once the preview deployment is ready).
https://living-dictionaries-irx55klgt-livingtongues.vercel.app/apatani/entries/gallery?entries_prod%5Btoggle%5D%5BhasImage%5D=true
http:://localhost:3041/apatani/entries/gallery?entries_prod%5Btoggle%5D%5BhasImage%5D=true