### PR TITLE
truncate only first author if authorString exceeds maximum length

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.test.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.test.ts
@@ -4,24 +4,33 @@ import { truncateAuthors } from './truncateAuthors';
 // most styles guides only invert the last name to the front for the first author for alphabetical reasons, after that we can rely on commas, 'and', and '&' to split authors.
 
 test('truncateAuthors just adds a comma after 1 author', () =>
-  expect(truncateAuthors('Anderson, Gregory D. S.'))
-    .toMatchInlineSnapshot('"Anderson, Gregory D. S., "'));
+  expect(truncateAuthors('Anderson, Gregory D. S.')).toMatchInlineSnapshot(
+    '"Anderson, Gregory D. S., "'
+  ));
 
 test('truncateAuthors leaves alone 2 authors below maxLengthLookingGoodInLetter', () =>
-  expect(truncateAuthors('Anderson, Gregory D. S. and Opino Gomango.'))
-    .toMatchInlineSnapshot('"Anderson, Gregory D. S. and Opino Gomango., "'));
+  expect(truncateAuthors('Anderson, Gregory D. S. and Opino Gomango.')).toMatchInlineSnapshot(
+    '"Anderson, Gregory D. S. and Opino Gomango., "'
+  ));
 
 test('truncateAuthors shortens 3 authors using an and exceeding maxLengthLookingGoodInLetter', () =>
-  expect(truncateAuthors('Derwing, Travis, Jamison Adler and James the Great Rossiter'))
-    .toMatchInlineSnapshot('"Derwing, Travis, Jamison Adler, et al., "'));
+  expect(
+    truncateAuthors('Derwing, Travis, Jamison Adler and James the Great Rossiter')
+  ).toMatchInlineSnapshot('"Derwing, et al., "'));
 
 test('truncateAuthors shortens 3 authors using an ampersand exceeding maxLengthLookingGoodInLetter', () =>
-  expect(truncateAuthors('Córdova, D., T. Derwing , A. O. Summo, M G. Davids, & E. R. Timmo'))
-    .toMatchInlineSnapshot('"Córdova, D., T. Derwing , A. O. Summo, et al., "'));
+  expect(
+    truncateAuthors('Córdova, D., T. Derwing , A. O. Summo, M G. Davids, & E. R. Timmo')
+  ).toMatchInlineSnapshot('"Córdova, et al., "'));
 
 test('truncateAuthors does not add an extra comma when maxLengthLookingGoodInLetter lands at an intersection of a comma plus ampersand', () =>
-  expect(truncateAuthors('Córdova, D., A. O. Summo, M G. Davids, & Edward. R. Timmo'))
-    .toMatchInlineSnapshot('"Córdova, D., A. O. Summo, M G. Davids, et al., "'));
+  expect(
+    truncateAuthors('Córdova, D., A. O. Summo, M G. Davids, & Edward. R. Timmo')
+  ).toMatchInlineSnapshot('"Córdova, et al., "'));
 
-test('Handles undefined', () =>
-  expect(truncateAuthors(undefined)).toMatchInlineSnapshot('""'));
+test('truncateAuthors shows the full name if no comma is used', () =>
+  expect(truncateAuthors('James Rock, Bob Smith, Joe Blow, and Jim Doe')).toMatchInlineSnapshot(
+    '"James Rock, et al., "'
+  ));
+
+test('Handles undefined', () => expect(truncateAuthors(undefined)).toMatchInlineSnapshot('""'));

--- a/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.ts
@@ -1,14 +1,12 @@
-const splitFirstAuthorRgx = /(,|and|&)/g;
+const maxLengthLookingGoodInLetter = 43;
+const firstCommaAndTypeOfDividerRgx = /(,|and|&)/;
 
-export function truncateAuthors(authorString: string): string {
-  if (!authorString) return '';
+export function truncateAuthors(authors: string): string {
+  if (!authors) return '';
+  if (authors.length < maxLengthLookingGoodInLetter) return authors + ', ';
 
-  const maxLengthLookingGoodInLetter = 43;
-  if (authorString.length > maxLengthLookingGoodInLetter) {
-    const truncatedFirstAuthor = authorString.split(splitFirstAuthorRgx)[0];
-    return addEtAlEnding(truncatedFirstAuthor);
-  }
-  return authorString + ', ';
+  const truncatedFirstAuthor = authors.split(firstCommaAndTypeOfDividerRgx)[0];
+  return addEtAlEnding(truncatedFirstAuthor);
 }
 
 function addEtAlEnding(authors: string): string {

--- a/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/truncateAuthors.ts
@@ -1,20 +1,12 @@
-const splitAuthorsRgx = /(?=,|and|&)/g;
+const splitFirstAuthorRgx = /(,|and|&)/g;
 
 export function truncateAuthors(authorString: string): string {
   if (!authorString) return '';
 
   const maxLengthLookingGoodInLetter = 43;
   if (authorString.length > maxLengthLookingGoodInLetter) {
-    let truncatedAuthors = '';
-    const authors = authorString.split(splitAuthorsRgx);
-    for (const author of authors) {
-      if (truncatedAuthors.length + author.length > maxLengthLookingGoodInLetter) {
-        truncatedAuthors = addEtAlEnding(truncatedAuthors);
-        break;
-      }
-      truncatedAuthors += author;
-    }
-    return truncatedAuthors;
+    const truncatedFirstAuthor = authorString.split(splitFirstAuthorRgx)[0];
+    return addEtAlEnding(truncatedFirstAuthor);
   }
   return authorString + ', ';
 }


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #247

#### Summarize what changed in this PR (for developers)
Modify truncateAuthors function to just use everything before the first divider (, and or &) + et al whether it is only a last name or a whole persons name written without being inverted.

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
https://living-dictionaries-fdi65kb8c-livingtongues.vercel.app/test-004/entries/print
http://localhost:3041/test-004/entries/print

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [x] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [x] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [x] Comments are only included when absolutely necessary information that cannot be explained in code is needed