### PR TITLE
allow string POS until we correctly refactor all entries

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -74,7 +74,7 @@ bg-white pt-1 -mt-1">
   <SeoMetaTags
     title={entry.lx}
     description={`${entry.lo ? entry.lo : ''} ${entry.lo2 ? entry.lo2 : ''} ${entry.lo3 ? entry.lo3 : ''}
-    ${entry.ph ? '[' + entry.ph + ']' : ''} ${entry.ps ? entry.ps.length > 1 ? entry.ps.join(', ') + '.' : entry.ps + '.' : ''}
+    ${entry.ph ? '[' + entry.ph + ']' : ''} ${entry.ps ? typeof entry.ps !=='string' && entry.ps.length > 1 ? entry.ps.join(', ') + '.' : entry.ps + '.' : ''}
     ${printGlosses(entry.gl, $t)
       .join(', ')
       .replace(/<\/?i>/g, '') + '.'}


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
Marvin Richardson found some problems on the Tutelo-saponi enties. After reviewing them, I found the SEO meta tags is not considering correctly Parts of speech that are still not refactored

#### Summarize what changed in this PR (for developers)

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed