### PR TITLE
glossing sort depends on the dictionary glossLanguages order

### DIFF
--- a/packages/site/src/lib/helpers/glosses.test.ts
+++ b/packages/site/src/lib/helpers/glosses.test.ts
@@ -1,4 +1,4 @@
-import { orderEntryAndDictionaryGlossLanguages, orderGlosses } from "./glosses";
+import { orderEntryAndDictionaryGlossLanguages, orderGlosses } from './glosses';
 
 describe('orderGlosses', () => {
   const $t = (id: string) => {
@@ -38,7 +38,8 @@ describe('orderGlosses', () => {
   });
 
   test('adds language label when label set to true', () => {
-    expect(orderGlosses({ glosses, dictionaryGlossLanguages, $t, label: true })).toMatchInlineSnapshot(`
+    expect(orderGlosses({ glosses, dictionaryGlossLanguages, $t, label: true }))
+      .toMatchInlineSnapshot(`
       [
         "German: apfel",
         "Spanish: manzana",
@@ -50,7 +51,7 @@ describe('orderGlosses', () => {
 
   test('handles an empty glosses object', () => {
     expect(orderGlosses({ glosses: {}, dictionaryGlossLanguages, $t })).toMatchInlineSnapshot('[]');
-  })
+  });
 
   test('example implementation with join and italics removal', () => {
     expect(
@@ -63,7 +64,8 @@ describe('orderGlosses', () => {
 
 describe('orderEntryAndDictionaryGlossLanguages', () => {
   test('places dictionary gloss languages first, then leftovers from gloss object but does not duplicate', () => {
-    expect(orderEntryAndDictionaryGlossLanguages({es: '', en: ''}, ['en', 'de'])).toMatchInlineSnapshot(`
+    expect(orderEntryAndDictionaryGlossLanguages({ es: '', en: '' }, ['en', 'de']))
+      .toMatchInlineSnapshot(`
       [
         "en",
         "de",

--- a/packages/site/src/lib/helpers/glosses.test.ts
+++ b/packages/site/src/lib/helpers/glosses.test.ts
@@ -1,0 +1,74 @@
+import { orderEntryAndDictionaryGlossLanguages, orderGlosses } from "./glosses";
+
+describe('orderGlosses', () => {
+  const $t = (id: string) => {
+    switch (id) {
+      case 'gl.de':
+        return 'German';
+      case 'gl.en':
+        return 'English';
+      case 'gl.es':
+        return 'Spanish';
+      default:
+        return 'other';
+    }
+  };
+
+  const glosses = {
+    en: 'apple',
+    es: 'manzana',
+    scientific: '<i>Neolamarckia cadamba</i>',
+    empty: '',
+    null: null,
+    de: 'apfel',
+  };
+  const dictionaryGlossLanguages = ['de', 'es', 'en'];
+
+  test('orders based on dictionaryGlossLanguages first', () => {
+    expect(orderGlosses({ glosses, dictionaryGlossLanguages, $t })).toMatchInlineSnapshot(
+      `
+        [
+          "apfel",
+          "manzana",
+          "apple",
+          "<i>Neolamarckia cadamba</i>",
+        ]
+        `
+    );
+  });
+
+  test('adds language label when label set to true', () => {
+    expect(orderGlosses({ glosses, dictionaryGlossLanguages, $t, label: true })).toMatchInlineSnapshot(`
+      [
+        "German: apfel",
+        "Spanish: manzana",
+        "English: apple",
+        "other: <i>Neolamarckia cadamba</i>",
+      ]
+      `);
+  });
+
+  test('handles an empty glosses object', () => {
+    expect(orderGlosses({ glosses: {}, dictionaryGlossLanguages, $t })).toMatchInlineSnapshot('[]');
+  })
+
+  test('example implementation with join and italics removal', () => {
+    expect(
+      orderGlosses({ glosses, dictionaryGlossLanguages, $t })
+        .join(', ')
+        .replace(/<\/?i>/g, '') + '.'
+    ).toMatchInlineSnapshot('"apfel, manzana, apple, Neolamarckia cadamba."');
+  });
+});
+
+describe('orderEntryAndDictionaryGlossLanguages', () => {
+  test('places dictionary gloss languages first, then leftovers from gloss object but does not duplicate', () => {
+    expect(orderEntryAndDictionaryGlossLanguages({es: '', en: ''}, ['en', 'de'])).toMatchInlineSnapshot(`
+      [
+        "en",
+        "de",
+        "es",
+      ]
+    `);
+  });
+});

--- a/packages/site/src/lib/helpers/glosses.ts
+++ b/packages/site/src/lib/helpers/glosses.ts
@@ -1,9 +1,13 @@
 import type { IGloss } from '@living-dictionaries/types';
 
-export function printGlosses(glosses: IGloss, t: (id: string) => string, { shorten = false } = {}) {
-  return Object.keys(glosses)
+export function printGlosses(
+  glosses: IGloss,
+  glossOrder: string[],
+  t: (id: string) => string,
+  { shorten = false } = {}
+) {
+  return glossOrder
     .filter((bcp) => glosses[bcp])
-    .sort() // sort by dictionary's gloss language order in the future
     .map((bcp) => {
       const gloss = glosses[bcp];
       if (shorten) return gloss;
@@ -11,41 +15,41 @@ export function printGlosses(glosses: IGloss, t: (id: string) => string, { short
     });
 }
 
-if (import.meta.vitest) {
-  const t = (id) => (id === 'gl.en' ? 'English' : 'Spanish');
-  test('printGlosses', () => {
-    const gloss = {
-      en: 'apple',
-      es: 'arbol',
-      scientific: '<i>Neolamarckia cadamba</i>',
-      empty: '',
-      null: null,
-    };
-    expect(printGlosses(gloss, t, { shorten: true })).toMatchInlineSnapshot(`
-      [
-        "apple",
-        "arbol",
-        "<i>Neolamarckia cadamba</i>",
-      ]
-    `);
+// if (import.meta.vitest) {
+//   const t = (id) => (id === 'gl.en' ? 'English' : 'Spanish');
+//   test('printGlosses', () => {
+//     const gloss = {
+//       en: 'apple',
+//       es: 'arbol',
+//       scientific: '<i>Neolamarckia cadamba</i>',
+//       empty: '',
+//       null: null,
+//     };
+//     expect(printGlosses(gloss, t, { shorten: true })).toMatchInlineSnapshot(`
+//       [
+//         "apple",
+//         "arbol",
+//         "<i>Neolamarckia cadamba</i>",
+//       ]
+//     `);
 
-    expect(printGlosses(gloss, t)).toMatchInlineSnapshot(`
-    [
-      "English: apple",
-      "Spanish: arbol",
-      "Spanish: <i>Neolamarckia cadamba</i>",
-    ]
-    `);
+//     expect(printGlosses(gloss, t)).toMatchInlineSnapshot(`
+//     [
+//       "English: apple",
+//       "Spanish: arbol",
+//       "Spanish: <i>Neolamarckia cadamba</i>",
+//     ]
+//     `);
 
-    expect(
-      printGlosses(gloss, t, { shorten: true })
-        .join(', ')
-        .replace(/<\/?i>/g, '') + '.'
-    ).toMatchInlineSnapshot('"apple, arbol, Neolamarckia cadamba."');
+//     expect(
+//       printGlosses(gloss, t, { shorten: true })
+//         .join(', ')
+//         .replace(/<\/?i>/g, '') + '.'
+//     ).toMatchInlineSnapshot('"apple, arbol, Neolamarckia cadamba."');
 
-    expect(printGlosses({}, t)).toMatchInlineSnapshot('[]');
-  });
-}
+//     expect(printGlosses({}, t)).toMatchInlineSnapshot('[]');
+//   });
+// }
 
 export function showEntryGlossLanguages(
   entryGlosses: { [key: string]: string },

--- a/packages/site/src/lib/helpers/glosses.ts
+++ b/packages/site/src/lib/helpers/glosses.ts
@@ -1,79 +1,27 @@
 import type { IGloss } from '@living-dictionaries/types';
 
-export function printGlosses(
-  glosses: IGloss,
-  glossOrder: string[],
-  t: (id: string) => string,
-  { shorten = false } = {}
-) {
-  const glossesMergedWithoutDuplicates = new Set([...glossOrder, ...Object.keys(glosses)]); //glossOrder must be in first place to sort correctly
-  const SortedGlossesArray = Array.from(glossesMergedWithoutDuplicates);
-  return SortedGlossesArray.filter((bcp) => glosses[bcp]).map((bcp) => {
-    const gloss = glosses[bcp];
-    if (shorten) return gloss;
-    return `${t('gl.' + bcp)}: ${gloss}`;
-  });
-}
-
-if (import.meta.vitest) {
-  const t = (id) => {
-    switch (id) {
-      case 'gl.de':
-        return 'German';
-      case 'gl.en':
-        return 'English';
-      case 'gl.es':
-        return 'Spanish';
-      default:
-        return 'other';
-    }
-  };
-  test('printGlosses', () => {
-    const gloss = {
-      en: 'apple',
-      es: 'manzana',
-      scientific: '<i>Neolamarckia cadamba</i>',
-      empty: '',
-      null: null,
-      de: 'apfel',
-    };
-    const glossOrderInDictionary = ['de', 'es', 'en'];
-    expect(printGlosses(gloss, glossOrderInDictionary, t, { shorten: true })).toMatchInlineSnapshot(
-      `
-      [
-        "apfel",
-        "manzana",
-        "apple",
-        "<i>Neolamarckia cadamba</i>",
-      ]
-    `
-    );
-
-    expect(printGlosses(gloss, glossOrderInDictionary, t)).toMatchInlineSnapshot(`
-      [
-        "German: apfel",
-        "Spanish: manzana",
-        "English: apple",
-        "other: <i>Neolamarckia cadamba</i>",
-      ]
-    `);
-
-    expect(
-      printGlosses(gloss, glossOrderInDictionary, t, { shorten: true })
-        .join(', ')
-        .replace(/<\/?i>/g, '') + '.'
-    ).toMatchInlineSnapshot('"apfel, manzana, apple, Neolamarckia cadamba."');
-
-    expect(printGlosses({}, glossOrderInDictionary, t)).toMatchInlineSnapshot('[]');
-  });
-}
-
-export function showEntryGlossLanguages(
-  entryGlosses: { [key: string]: string },
-  dictionaryLanguages: string[]
-) {
-  if (entryGlosses) {
-    return [...new Set([...dictionaryLanguages, ...Object.keys(entryGlosses)])];
+export function orderGlosses({ glosses, dictionaryGlossLanguages, $t, label = false }:
+  {
+    glosses: IGloss;
+    dictionaryGlossLanguages: string[],
+    $t: (id: string) => string,
+    label?: boolean
   }
-  return [...new Set(dictionaryLanguages)];
+) {
+  const sortedGlossLanguages = orderEntryAndDictionaryGlossLanguages(glosses, dictionaryGlossLanguages);
+  const glossLanguagesWithGloss = sortedGlossLanguages.filter((bcp) => glosses[bcp])
+  return glossLanguagesWithGloss.map((bcp) => {
+    const gloss = glosses[bcp];
+    if (label) return `${$t('gl.' + bcp)}: ${gloss}`;
+    return gloss;
+  });
+}
+
+export function orderEntryAndDictionaryGlossLanguages(
+  glosses: IGloss,
+  dictionaryGlossLanguages: string[]
+) {
+  const combinedGlossingLanguages = [...dictionaryGlossLanguages, ...Object.keys(glosses || {})]
+  const deduplicatedGlossingLanguages = [...new Set(combinedGlossingLanguages)]
+  return deduplicatedGlossingLanguages;
 }

--- a/packages/site/src/lib/helpers/glosses.ts
+++ b/packages/site/src/lib/helpers/glosses.ts
@@ -15,41 +15,41 @@ export function printGlosses(
     });
 }
 
-// if (import.meta.vitest) {
-//   const t = (id) => (id === 'gl.en' ? 'English' : 'Spanish');
-//   test('printGlosses', () => {
-//     const gloss = {
-//       en: 'apple',
-//       es: 'arbol',
-//       scientific: '<i>Neolamarckia cadamba</i>',
-//       empty: '',
-//       null: null,
-//     };
-//     expect(printGlosses(gloss, t, { shorten: true })).toMatchInlineSnapshot(`
-//       [
-//         "apple",
-//         "arbol",
-//         "<i>Neolamarckia cadamba</i>",
-//       ]
-//     `);
+if (import.meta.vitest) {
+  const t = (id) => (id === 'gl.en' ? 'English' : 'Spanish');
+  test('printGlosses', () => {
+    const gloss = {
+      en: 'apple',
+      es: 'arbol',
+      scientific: '<i>Neolamarckia cadamba</i>',
+      empty: '',
+      null: null,
+    };
+    const glossOrderInDictionary = ['es', 'en'];
+    expect(printGlosses(gloss, glossOrderInDictionary, t, { shorten: true }))
+      .toMatchInlineSnapshot(`
+        [
+          "arbol",
+          "apple",
+        ]
+      `);
 
-//     expect(printGlosses(gloss, t)).toMatchInlineSnapshot(`
-//     [
-//       "English: apple",
-//       "Spanish: arbol",
-//       "Spanish: <i>Neolamarckia cadamba</i>",
-//     ]
-//     `);
+    expect(printGlosses(gloss, glossOrderInDictionary, t)).toMatchInlineSnapshot(`
+      [
+        "Spanish: arbol",
+        "English: apple",
+      ]
+    `);
 
-//     expect(
-//       printGlosses(gloss, t, { shorten: true })
-//         .join(', ')
-//         .replace(/<\/?i>/g, '') + '.'
-//     ).toMatchInlineSnapshot('"apple, arbol, Neolamarckia cadamba."');
+    expect(
+      printGlosses(gloss, glossOrderInDictionary, t, { shorten: true })
+        .join(', ')
+        .replace(/<\/?i>/g, '') + '.'
+    ).toMatchInlineSnapshot('"arbol, apple."');
 
-//     expect(printGlosses({}, t)).toMatchInlineSnapshot('[]');
-//   });
-// }
+    expect(printGlosses({}, glossOrderInDictionary, t)).toMatchInlineSnapshot('[]');
+  });
+}
 
 export function showEntryGlossLanguages(
   entryGlosses: { [key: string]: string },

--- a/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
@@ -6,11 +6,10 @@
   import AddImage from '../AddImage.svelte';
   import { page } from '$app/stores';
   import type { IEntry } from '@living-dictionaries/types';
-  import { orderGlosses } from '$lib/helpers/glosses';
+  import { orderGlosses, orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
   import { minutesAgo } from '$lib/helpers/time';
   import { deleteImage } from '$lib/helpers/delete';
   import ShowHide from 'svelte-pieces/functions/ShowHide.svelte';
-  import { orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
   import { dictionary } from '$lib/stores';
   import sanitize from 'xss';
 

--- a/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
@@ -18,7 +18,7 @@
     canEdit = false,
     videoAccess = false;
 
-  $: glosses = printGlosses(entry.gl, $t, {
+  $: glosses = printGlosses(entry.gl, $dictionary.glossLanguages, $t, {
     shorten: $dictionary.id === 'jewish-neo-aramaic',
   }).join(', ');
 </script>

--- a/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
@@ -6,11 +6,11 @@
   import AddImage from '../AddImage.svelte';
   import { page } from '$app/stores';
   import type { IEntry } from '@living-dictionaries/types';
-  import { printGlosses } from '$lib/helpers/glosses';
+  import { orderGlosses } from '$lib/helpers/glosses';
   import { minutesAgo } from '$lib/helpers/time';
   import { deleteImage } from '$lib/helpers/delete';
   import ShowHide from 'svelte-pieces/functions/ShowHide.svelte';
-  import { showEntryGlossLanguages } from '$lib/helpers/glosses';
+  import { orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
   import { dictionary } from '$lib/stores';
   import sanitize from 'xss';
 
@@ -18,8 +18,11 @@
     canEdit = false,
     videoAccess = false;
 
-  $: glosses = printGlosses(entry.gl, $dictionary.glossLanguages, $t, {
-    shorten: $dictionary.id === 'jewish-neo-aramaic',
+  $: glosses = orderGlosses({
+    glosses: entry.gl,
+    dictionaryGlossLanguages: $dictionary.glossLanguages,
+    $t,
+    label: $dictionary.id !== 'jewish-neo-aramaic',
   }).join(', ');
 </script>
 
@@ -75,7 +78,7 @@
               {entry.xs.vn}
             </p>{/if}
           {#if entry.xs}
-            {#each showEntryGlossLanguages(entry.gl, $dictionary.glossLanguages) as bcp}
+            {#each orderEntryAndDictionaryGlossLanguages(entry.gl, $dictionary.glossLanguages) as bcp}
               {#if entry.xs[bcp]}
                 <p>
                   <span class="font-semibold"

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.svelte
@@ -2,6 +2,8 @@
   import { t } from 'svelte-i18n';
   import { StandardPrintFields, type IEntry } from '@living-dictionaries/types';
   import { semanticDomains } from '$lib/mappings/semantic-domains';
+  import { orderGlosses } from '$lib/helpers/glosses';
+  import { dictionary } from '$lib/stores';
   import QrCode from './QrCode.svelte';
   import sanitize from 'xss';
   import { defaultPrintFields } from './printFields';
@@ -32,10 +34,13 @@
   {entry.ph && selectedFields.ph ? `/${entry.ph}/` : ''}
   <i>{entry.ps && selectedFields.ps ? entry.ps : ''}</i>
   {#if entry.gl && selectedFields.gloss}
-    {#each Object.entries(entry.gl) as gloss, index}
-      <span>{@html sanitize(gloss[1])}</span>
-      {index < Object.entries(entry.gl).length - 1 ? ' - ' : ''}
-    {/each}
+    <span>
+      {@html sanitize(orderGlosses({
+        glosses: entry.gl,
+        dictionaryGlossLanguages: $dictionary.glossLanguages,
+        $t,
+      }).join(' - '))}
+    </span>
   {/if}
   <b>{entry.xv && selectedFields.example_sentence ? entry.xv : ''}</b>
   {#if entry.xs && selectedFields.example_sentence}

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -15,8 +15,8 @@
   import { deleteEntry } from '$lib/helpers/delete';
   import { saveUpdateToFirestore } from '$lib/helpers/entry/update';
   import SeoMetaTags from '$lib/components/SeoMetaTags.svelte';
-  import { printGlosses } from '$lib/helpers/glosses';
-  import { showEntryGlossLanguages } from '$lib/helpers/glosses';
+  import { orderGlosses } from '$lib/helpers/glosses';
+  import { orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
   import EntryDisplay from './EntryDisplay.svelte';
 
   import type { PageData } from './$types';
@@ -67,17 +67,27 @@ bg-white pt-1 -mt-1">
     {entry}
     videoAccess={$dictionary.videoAccess || $admin > 0}
     canEdit={$canEdit}
-    glossingLanguages={showEntryGlossLanguages(entry.gl, $dictionary.glossLanguages)}
+    glossingLanguages={orderEntryAndDictionaryGlossLanguages(entry.gl, $dictionary.glossLanguages)}
     alternateOrthographies={$dictionary.alternateOrthographies || []}
     on:valueupdate={(e) => saveUpdateToFirestore(e, entry.id, $dictionary.id)} />
 
   <SeoMetaTags
     title={entry.lx}
-    description={`${entry.lo ? entry.lo : ''} ${entry.lo2 ? entry.lo2 : ''} ${entry.lo3 ? entry.lo3 : ''}
-    ${entry.ph ? '[' + entry.ph + ']' : ''} ${entry.ps ? typeof entry.ps !=='string' && entry.ps.length > 1 ? entry.ps.join(', ') + '.' : entry.ps + '.' : ''}
-    ${printGlosses(entry.gl, $dictionary.glossLanguages, $t)
-      .join(', ')
-      .replace(/<\/?i>/g, '') + '.'}
+    description={`${entry.lo ? entry.lo : ''} ${entry.lo2 ? entry.lo2 : ''} ${
+      entry.lo3 ? entry.lo3 : ''
+    }
+    ${entry.ph ? '[' + entry.ph + ']' : ''} ${
+      entry.ps
+        ? typeof entry.ps !== 'string' && entry.ps.length > 1
+          ? entry.ps.join(', ') + '.'
+          : entry.ps + '.'
+        : ''
+    }
+    ${
+      orderGlosses({ glosses: entry.gl, dictionaryGlossLanguages: $dictionary.glossLanguages, $t, label: true })
+        .join(', ')
+        .replace(/<\/?i>/g, '') + '.'
+    }
     ${entry.di ? entry.di : ''}`.replace(/(?<!\w)\n/gm, '')}
     dictionaryName={$dictionary.name}
     lat={$dictionary.coordinates?.latitude}

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -75,7 +75,7 @@ bg-white pt-1 -mt-1">
     title={entry.lx}
     description={`${entry.lo ? entry.lo : ''} ${entry.lo2 ? entry.lo2 : ''} ${entry.lo3 ? entry.lo3 : ''}
     ${entry.ph ? '[' + entry.ph + ']' : ''} ${entry.ps ? typeof entry.ps !=='string' && entry.ps.length > 1 ? entry.ps.join(', ') + '.' : entry.ps + '.' : ''}
-    ${printGlosses(entry.gl, $t)
+    ${printGlosses(entry.gl, $dictionary.glossLanguages, $t)
       .join(', ')
       .replace(/<\/?i>/g, '') + '.'}
     ${entry.di ? entry.di : ''}`.replace(/(?<!\w)\n/gm, '')}

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -15,8 +15,7 @@
   import { deleteEntry } from '$lib/helpers/delete';
   import { saveUpdateToFirestore } from '$lib/helpers/entry/update';
   import SeoMetaTags from '$lib/components/SeoMetaTags.svelte';
-  import { orderGlosses } from '$lib/helpers/glosses';
-  import { orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
+  import { orderGlosses, orderEntryAndDictionaryGlossLanguages } from '$lib/helpers/glosses';
   import EntryDisplay from './EntryDisplay.svelte';
 
   import type { PageData } from './$types';
@@ -84,7 +83,12 @@ bg-white pt-1 -mt-1">
         : ''
     }
     ${
-      orderGlosses({ glosses: entry.gl, dictionaryGlossLanguages: $dictionary.glossLanguages, $t, label: true })
+      orderGlosses({
+        glosses: entry.gl,
+        dictionaryGlossLanguages: $dictionary.glossLanguages,
+        $t,
+        label: true,
+      })
         .join(', ')
         .replace(/<\/?i>/g, '') + '.'
     }

--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -22,7 +22,6 @@ const config: UserConfig = {
     'import.meta.vitest': false,
     'import.meta.env.VERCEL_ANALYTICS_ID': JSON.stringify(process.env.VERCEL_ANALYTICS_ID),
   },
-  // @ts-ignore
   test: {
     // plugins: [svelte({ hot: !process.env.VITEST })],
     globals: true,


### PR DESCRIPTION
#### Relevant Issue

#### Summarize what changed in this PR (for developers)
This is a partial change to relief the needs of the Mayunmarka community to display a specific order in their glosses.
It will also work for the[ new functionality I'm working on](https://github.com/livingtongues/living-dictionaries/issues/264) since it will always load the order from the specific `dictionary.glossLanguages` field

#### How can the changes be tested? 
/bezhta/entries/list
(I changed the russian gloss to be the first in development DB)
https://living-dictionaries-cycci68yd-livingtongues.vercel.app/bezhta/entries/list

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [x] Functions
    - [x] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [x] Functions are short and well named
    - [x] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [x] Comments are only included when absolutely necessary information that cannot be explained in code is needed