### PR TITLE
Fix kharia semantic domains

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,13 +14,16 @@
     "updateIndex": "tsx algolia/updateIndex.ts -e prod",
     "copyAlgoliaIndexRecords": "tsx algolia/copyAlgoliaIndexRecords.js",
     "copyAlgoliaIndexSettings": "tsx algolia/copyAlgoliaIndexSettings.js",
-    "test": "vitest -u"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "devDependencies": {
     "@living-dictionaries/functions": "workspace:^0.0.1",
     "@living-dictionaries/parts": "workspace:^0.0.1",
+    "@living-dictionaries/site": "workspace:^0.0.1",
     "@living-dictionaries/types": "^1.0.0",
     "@types/node": "^18.11.18",
+    "@vitest/ui": "^0.28.4",
     "algoliasearch": "^4.11.0",
     "commander": "^9.4.1",
     "csv-parse": "^5.3.0",

--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -16,10 +16,10 @@ async function entryRefactor() {
       console.log(`---Refactoring: ${dictionaryId}`);
       await fetchEntries(dictionaryId);
     } else {
-      const snapshot = await db.collection('dictionaries').get()
+      const snapshot = await db.collection('dictionaries').get();
       for (const dictionarySnap of snapshot.docs) {
         // If setting limits on refactoring, you can skip dictionaries beginning with letters that have already been processed:
-        const done = /^[abcdefghijklmn].*/
+        const done = /^[abcdefghijklmn].*/;
         if (!done.test(dictionarySnap.id.toLowerCase())) {
           console.log(`---Refactoring: ${dictionarySnap.id}`);
           await fetchEntries(dictionarySnap.id);
@@ -33,7 +33,7 @@ async function entryRefactor() {
 }
 
 async function fetchEntries(dictionaryId: string) {
-  const snapshot = await db.collection(`dictionaries/${dictionaryId}/words`).get()
+  const snapshot = await db.collection(`dictionaries/${dictionaryId}/words`).get();
   for (const snap of snapshot.docs) {
     const entry: IEntry = { id: snap.id, ...(snap.data() as IEntry) };
     // await turnSDintoArray(dictionaryId, entry);
@@ -42,6 +42,8 @@ async function fetchEntries(dictionaryId: string) {
     turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
   }
 }
+
+//TODO reverese_semantic_domains_in_db
 
 const turnSDintoArray = async (dictionaryId: string, entry: IEntry) => {
   if (entry.sd && typeof entry.sd === 'string') {

--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -1,6 +1,7 @@
 import { IEntry } from '@living-dictionaries/types';
 import { db } from '../config';
 import { program } from 'commander';
+import { reverse_semantic_domains_mapping } from './reverse-semantic-domains-mapping';
 program
   //   .version('0.0.1')
   .option('--id <value>', 'Dictionary Id')
@@ -39,11 +40,23 @@ async function fetchEntries(dictionaryId: string) {
     // await turnSDintoArray(dictionaryId, entry);
     // await refactorGloss(dictionaryId, entry);
     // await notesToPluralForm(dictionaryId, entry);
-    turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
+    // turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
+    reverese_semantic_domains_in_db(dictionaryId, entry);
   }
 }
 
-//TODO reverese_semantic_domains_in_db
+const reverese_semantic_domains_in_db = async (dictionaryId: string, entry: IEntry) => {
+  if (entry.sdn) {
+    console.log('entry sdn before:');
+    console.log(entry.sdn);
+    entry.sdn = reverse_semantic_domains_mapping(entry.sdn);
+  }
+  console.log('entry sdn after:');
+  console.log(entry.sdn);
+  if (!live) return;
+  await db.collection(`dictionaries/${dictionaryId}/words`).doc(entry.id).set(entry);
+  return true;
+};
 
 const turnSDintoArray = async (dictionaryId: string, entry: IEntry) => {
   if (entry.sd && typeof entry.sd === 'string') {

--- a/packages/scripts/refactor/inverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/inverse-semantic-domains-mapping.ts
@@ -1,0 +1,62 @@
+import { semanticDomains } from '../../site/src/lib/mappings/semantic-domains';
+
+export function inverse_semantic_domains_mapping(semantic_domains: string[]): string[] {
+  const cleaned_semantic_domains = clean_semantic_domains(semantic_domains);
+  const sdn = cleaned_semantic_domains.map(
+    (semantic_domain) => semanticDomains.find((sd) => sd.name === semantic_domain).key
+  );
+  return sdn;
+}
+
+function clean_semantic_domains(semantic_domains: string[]): string[] {
+  const cleaned_semantic_domains = semantic_domains.map((sd) => {
+    if (sd.includes('-')) {
+      return sd.replace(/ -/g, ',');
+    } else {
+      return sd;
+    }
+  });
+  return cleaned_semantic_domains;
+}
+
+if (import.meta.vitest) {
+  test('cleans semantic domains', () => {
+    const semantic_domains = [
+      'Motion',
+      'Pro-forms',
+      'Spirituality and Religion',
+      'Humans - Social Relations and Organization',
+      'Health - well-being and sickness',
+      'Coordinators - Subordinators - Relativizers - Quotatives',
+    ];
+    expect(clean_semantic_domains(semantic_domains)).toEqual([
+      'Motion',
+      'Pro-forms',
+      'Spirituality and Religion',
+      'Humans, Social Relations and Organization',
+      'Health, well-being and sickness',
+      'Coordinators, Subordinators, Relativizers, Quotatives',
+    ]);
+  });
+
+  test.each([
+    {
+      sdn: ['TAM'],
+      expected: ['10.2'],
+    },
+    {
+      sdn: ['Universe and the natural world', 'Earth, geology and landscape'],
+      expected: ['1', '1.2'],
+    },
+    {
+      sdn: ['Names', 'Emotions', 'Birds', 'Colors', 'Animals'],
+      expected: ['4', '3.2', '1.7', '1.6', '1.5'],
+    },
+    {
+      sdn: ['Health - well-being and sickness', 'Earth - geology and landscape'],
+      expected: ['2.4', '1.2'],
+    },
+  ])('inverse semantic domains mapping', ({ sdn, expected }) => {
+    expect(inverse_semantic_domains_mapping(sdn)).toEqual(expected);
+  });
+}

--- a/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
@@ -3,6 +3,7 @@ import { semanticDomains } from '../../site/src/lib/mappings/semantic-domains';
 export function reverse_semantic_domains_mapping(semantic_domains: string[]): string[] {
   const cleaned_semantic_domains = clean_semantic_domains(semantic_domains);
   const semantic_domain_number = cleaned_semantic_domains.map((semantic_domain) => {
+    semantic_domain = update_old_semantic_domains(semantic_domain);
     const sdn = semanticDomains.find((sd) => sd.name === semantic_domain);
     return sdn ? sdn.key : semantic_domain;
   });
@@ -17,6 +18,15 @@ function clean_semantic_domains(semantic_domains: string[]): string[] {
     return sd;
   });
   return cleaned_semantic_domains;
+}
+
+function update_old_semantic_domains(semantic_domain: string): string {
+  if (semantic_domain === 'States') {
+    return 'States and Characteristics';
+  } else if (semantic_domain === 'Physical Actions and States') {
+    return 'Physical Actions';
+  }
+  return semantic_domain;
 }
 
 if (import.meta.vitest) {
@@ -59,6 +69,10 @@ if (import.meta.vitest) {
     {
       sdn: ['2.4', '1.2'],
       expected: ['2.4', '1.2'],
+    },
+    {
+      sdn: ['States', 'Physical Actions and States'],
+      expected: ['6.5', '6'],
     },
   ])('inverse semantic domains mapping', ({ sdn, expected }) => {
     expect(reverse_semantic_domains_mapping(sdn)).toEqual(expected);

--- a/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
@@ -12,9 +12,8 @@ function clean_semantic_domains(semantic_domains: string[]): string[] {
   const cleaned_semantic_domains = semantic_domains.map((sd) => {
     if (sd.includes('-')) {
       return sd.replace(/ -/g, ',');
-    } else {
-      return sd;
     }
+    return sd;
   });
   return cleaned_semantic_domains;
 }

--- a/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
@@ -2,10 +2,11 @@ import { semanticDomains } from '../../site/src/lib/mappings/semantic-domains';
 
 export function reverse_semantic_domains_mapping(semantic_domains: string[]): string[] {
   const cleaned_semantic_domains = clean_semantic_domains(semantic_domains);
-  const sdn = cleaned_semantic_domains.map(
-    (semantic_domain) => semanticDomains.find((sd) => sd.name === semantic_domain).key
-  );
-  return sdn;
+  const semantic_domain_number = cleaned_semantic_domains.map((semantic_domain) => {
+    const sdn = semanticDomains.find((sd) => sd.name === semantic_domain);
+    return sdn ? sdn.key : semantic_domain;
+  });
+  return semantic_domain_number;
 }
 
 function clean_semantic_domains(semantic_domains: string[]): string[] {
@@ -53,6 +54,10 @@ if (import.meta.vitest) {
     },
     {
       sdn: ['Health - well-being and sickness', 'Earth - geology and landscape'],
+      expected: ['2.4', '1.2'],
+    },
+    {
+      sdn: ['2.4', '1.2'],
       expected: ['2.4', '1.2'],
     },
   ])('inverse semantic domains mapping', ({ sdn, expected }) => {

--- a/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
@@ -1,6 +1,6 @@
 import { semanticDomains } from '../../site/src/lib/mappings/semantic-domains';
 
-export function inverse_semantic_domains_mapping(semantic_domains: string[]): string[] {
+export function reverse_semantic_domains_mapping(semantic_domains: string[]): string[] {
   const cleaned_semantic_domains = clean_semantic_domains(semantic_domains);
   const sdn = cleaned_semantic_domains.map(
     (semantic_domain) => semanticDomains.find((sd) => sd.name === semantic_domain).key
@@ -57,6 +57,6 @@ if (import.meta.vitest) {
       expected: ['2.4', '1.2'],
     },
   ])('inverse semantic domains mapping', ({ sdn, expected }) => {
-    expect(inverse_semantic_domains_mapping(sdn)).toEqual(expected);
+    expect(reverse_semantic_domains_mapping(sdn)).toEqual(expected);
   });
 }

--- a/packages/scripts/vitest.config.ts
+++ b/packages/scripts/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    includeSource: ['./import/**/*.ts'],
+    includeSource: ['./import/**/*.ts', './refactor/*.ts'],
   },
 });

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "site",
+  "name": "@living-dictionaries/site",
   "version": "0.0.1",
+  "description": "livingdictionaries.app",
+  "type": "module",
+  "main": "src/lib/index.ts",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
@@ -60,7 +63,6 @@
     "web-vitals": "^2.1.2",
     "xss": "^1.0.14"
   },
-  "type": "module",
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },

--- a/packages/site/src/lib/index.ts
+++ b/packages/site/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { semanticDomains } from './mappings/semantic-domains';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,10 @@ importers:
     specifiers:
       '@living-dictionaries/functions': workspace:^0.0.1
       '@living-dictionaries/parts': workspace:^0.0.1
+      '@living-dictionaries/site': workspace:^0.0.1
       '@living-dictionaries/types': ^1.0.0
       '@types/node': ^18.11.18
+      '@vitest/ui': ^0.28.4
       algoliasearch: ^4.11.0
       commander: ^9.4.1
       csv-parse: ^5.3.0
@@ -153,8 +155,10 @@ importers:
     devDependencies:
       '@living-dictionaries/functions': link:../functions
       '@living-dictionaries/parts': link:../parts
+      '@living-dictionaries/site': link:../site
       '@living-dictionaries/types': link:../types
       '@types/node': 18.11.18
+      '@vitest/ui': 0.28.4
       algoliasearch: 4.13.0
       commander: 9.4.1
       csv-parse: 5.3.0
@@ -166,7 +170,7 @@ importers:
       node-fetch: 3.2.3
       tsx: 3.12.1
       typescript: 4.9.4
-      vitest: 0.28.4
+      vitest: 0.28.4_@vitest+ui@0.28.4
 
   packages/site:
     specifiers:
@@ -1823,8 +1827,8 @@ packages:
       unist-util-visit: 4.1.2
     dev: true
 
-  /@kitbook/vite-plugin-kitbook/0.0.5_svelte@3.55.1:
-    resolution: {integrity: sha512-QqpuH8fEvy3Weum1hCDcJQRpn+6J6IAQ3EJWYNbaCw7ZP/KV+dBOQ9nBxkrgQHc841Z8XVWT3GL2OOpcrI84Qg==}
+  /@kitbook/vite-plugin-kitbook/0.0.6_svelte@3.55.1:
+    resolution: {integrity: sha512-ijtlfbUKsJ0PKL9CYR3KKwITiKQQYtY/gXOrFCsrGmOaV++vtUPowvL8FZ1ESnwwAMel+b3SRq7SAH8jyLEs9w==}
     dependencies:
       '@kitbook/mdsvex-shiki-twoslash': 0.0.3_svelte@3.55.1
       '@kitbook/rehype-display-link-titles': 0.0.3
@@ -6792,7 +6796,7 @@ packages:
     resolution: {integrity: sha512-8KImYGrlvfO2nGKTN9D/jVYSyB1gXCjpS8SEOP0mwl/NhqnQNfMT/dpKBZdCzF+SJthBQLqE7zGynD/esXuxzw==}
     dependencies:
       '@kitbook/mdsvex-shiki-twoslash': 0.0.3_svelte@3.55.1
-      '@kitbook/vite-plugin-kitbook': 0.0.5_svelte@3.55.1
+      '@kitbook/vite-plugin-kitbook': 0.0.6_svelte@3.55.1
       lz-string: 1.4.4
       svelte: 3.55.1
       svelte-pieces: 1.0.57_svelte@3.55.1


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #278 

#### Summarize what changed in this PR (for developers)
create script for reverse the semantic domains mapping in Kharia sdn fields 

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
(on the backend run) pnpm entryRefactor -- --id kharia


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [x] Functions
    - [x] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [x] Functions are short and well named
    - [x] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [x] Comments are only included when absolutely necessary information that cannot be explained in code is needed