### PR TITLE
add torwali to display variant field

### DIFF
--- a/packages/site/src/lib/export/formatEntries.ts
+++ b/packages/site/src/lib/export/formatEntries.ts
@@ -89,7 +89,7 @@ export function formatEntriesForCSV(
       pl: entry.pl,
       di: entry.di,
       nt: stripHTMLTags(entry.nt),
-      sr: entry.sr ? typeof entry.sr === 'string' ? entry.sr : entry.sr.join(' | ') : '', // some dictionaries (e.g. Kalanga) have sources that are strings and not arrays
+      sr: entry.sr ? (typeof entry.sr === 'string' ? entry.sr : entry.sr.join(' | ')) : '', // some dictionaries (e.g. Kalanga) have sources that are strings and not arrays
       psab: '',
       ps: '',
       sfFriendlyName: '',
@@ -153,7 +153,7 @@ export function formatEntriesForCSV(
     });
 
     // Dictionary specific
-    if (dictionaryId === 'babanki') {
+    if (['babanki', 'torwali'].includes(dictionaryId)) {
       formattedEntry.va = entry.va;
     }
 

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/EntryDisplay.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/EntryDisplay.svelte
@@ -89,7 +89,7 @@
 
     <EntrySemanticDomains {canEdit} {entry} on:valueupdate />
 
-    {#if $dictionary.id === 'babanki'}
+    {#if  ['babanki', 'torwali'].includes($dictionary.id)}
       <EntryField
         value={entry['va']}
         field="va"


### PR DESCRIPTION
#### Relevant Issue


#### Summarize what changed in this PR (for developers)
Only add Torwali to the array for displaying the variant field

#### How can the changes be tested? 


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed