### PR TITLE
add move_dialect_to_notes fn

### DIFF
--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -42,7 +42,7 @@ async function fetchEntries(dictionaryId: string) {
     // await notesToPluralForm(dictionaryId, entry);
     // turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
     // reverese_semantic_domains_in_db(dictionaryId, entry);
-    move_dialect_to_notes(dictionaryId, entry, 'Example: ');
+    move_dialect_to_notes(dictionaryId, entry, '');
   }
 }
 
@@ -64,18 +64,20 @@ const move_dialect_to_notes = async (
   entry: IEntry,
   manual_text: string = null
 ) => {
-  if (entry.di && manual_text) {
+  if (entry.di) {
     console.log('entry dialect before:');
     console.log(entry.di);
-    if (entry.nt) {
-      console.log('entry notes before:');
-      console.log(entry?.nt);
-      entry.nt = `${entry?.nt}<br>${manual_text}${entry.di}`;
-    } else {
-      entry.nt = `${manual_text}${entry.di}`;
+    if (manual_text !== null) {
+      if (entry.nt) {
+        console.log('entry notes before:');
+        console.log(entry?.nt);
+        entry.nt = `${entry?.nt}<p>${manual_text}${entry.di}</p>`;
+      } else {
+        entry.nt = `${manual_text}${entry.di}`;
+      }
+      console.log('entry notes after:');
+      console.log(entry.nt);
     }
-    console.log('entry notes after:');
-    console.log(entry.nt);
   }
   delete entry.di;
   if (!live) return;

--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -42,7 +42,7 @@ async function fetchEntries(dictionaryId: string) {
     // await notesToPluralForm(dictionaryId, entry);
     // turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
     // reverese_semantic_domains_in_db(dictionaryId, entry);
-    move_dialect_to_notes(dictionaryId, entry, '');
+    move_dialect_to_notes(dictionaryId, entry, ''); // if the manual_text parameter is not provided, the function will only delete the dialect field;
   }
 }
 

--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -65,7 +65,7 @@ const move_dialect_to_notes = async (
   manual_text: string = null
 ) => {
   if (entry.di) {
-    console.log('entry dialect before:');
+    console.log('entry dialect before deleting it:');
     console.log(entry.di);
     if (manual_text !== null) {
       if (entry.nt) {

--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -41,7 +41,8 @@ async function fetchEntries(dictionaryId: string) {
     // await refactorGloss(dictionaryId, entry);
     // await notesToPluralForm(dictionaryId, entry);
     // turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
-    reverese_semantic_domains_in_db(dictionaryId, entry);
+    // reverese_semantic_domains_in_db(dictionaryId, entry);
+    move_dialect_to_notes(dictionaryId, entry, 'Example: ');
   }
 }
 
@@ -53,6 +54,30 @@ const reverese_semantic_domains_in_db = async (dictionaryId: string, entry: IEnt
   }
   console.log('entry sdn after:');
   console.log(entry.sdn);
+  if (!live) return;
+  await db.collection(`dictionaries/${dictionaryId}/words`).doc(entry.id).set(entry);
+  return true;
+};
+
+const move_dialect_to_notes = async (
+  dictionaryId: string,
+  entry: IEntry,
+  manual_text: string = null
+) => {
+  if (entry.di && manual_text) {
+    console.log('entry dialect before:');
+    console.log(entry.di);
+    if (entry.nt) {
+      console.log('entry notes before:');
+      console.log(entry?.nt);
+      entry.nt = `${entry?.nt}<br>${manual_text}${entry.di}`;
+    } else {
+      entry.nt = `${manual_text}${entry.di}`;
+    }
+    console.log('entry notes after:');
+    console.log(entry.nt);
+  }
+  delete entry.di;
   if (!live) return;
   await db.collection(`dictionaries/${dictionaryId}/words`).doc(entry.id).set(entry);
   return true;


### PR DESCRIPTION
#### Relevant Issue


#### Summarize what changed in this PR (for developers)
Create a function to move all information that was initially store in dialects to notes in different dictionaries

#### How can the changes be tested? 


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed