### PR TITLE
add Wancho font with Fontsource

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -19,6 +19,7 @@
     "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@fontsource/noto-sans-wancho": "^5.0.2",
     "@iconify/json": "^2.2.49",
     "@living-dictionaries/parts": "workspace:^0.0.1",
     "@living-dictionaries/types": "workspace:^1.0.0",
@@ -58,7 +59,7 @@
     "sveltefirets": "^0.0.36",
     "temp-s-p-u": "^0.0.7",
     "tslib": "^2.4.1",
-		"typescript": "^5.0.0",
+    "typescript": "^5.0.0",
     "unocss": "^0.48.0",
     "vite": "^4.1.1",
     "vitest": "^0.29.7",

--- a/packages/site/src/routes/[dictionaryId]/+layout.svelte
+++ b/packages/site/src/routes/[dictionaryId]/+layout.svelte
@@ -5,6 +5,7 @@
   import Header from '$lib/components/shell/Header.svelte';
   import { Button, ResponsiveSlideover } from 'svelte-pieces';
   import type { LayoutData } from './$types';
+  import '@fontsource/noto-sans-wancho';
   export let data: LayoutData;
 
   if (data.dictionary) {

--- a/packages/site/static/tw-reset.css
+++ b/packages/site/static/tw-reset.css
@@ -24,7 +24,9 @@ html {
   -webkit-text-size-adjust: 100%; /* 2 */
   -moz-tab-size: 4; /* 3 */
   tab-size: 4; /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', 'Noto Sans Wancho', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; /* 4 */
 }
 
 /*
@@ -98,7 +100,8 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; /* 1 */
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 
@@ -315,7 +318,7 @@ Set the default cursor for buttons.
 */
 
 button,
-[role="button"] {
+[role='button'] {
   cursor: pointer;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
 
   packages/site:
     devDependencies:
+      '@fontsource/noto-sans-wancho':
+        specifier: ^5.0.2
+        version: 5.0.2
       '@iconify/json':
         specifier: ^2.2.49
         version: 2.2.49
@@ -1818,6 +1821,10 @@ packages:
 
   /@firebase/webchannel-wrapper@0.3.0:
     resolution: {integrity: sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==}
+    dev: true
+
+  /@fontsource/noto-sans-wancho@5.0.2:
+    resolution: {integrity: sha512-uN/gri13zS614FZi28SJxIxxWt5uW+P+KspJs8YobCYrNddSP9niBz7LyrgN23XNAm40NQ97omWpBxOBhbwsMQ==}
     dev: true
 
   /@formatjs/ecma402-abstract@1.11.4:


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #317 

#### Summarize what changed in this PR (for developers)
use of Fontsource project to install the Wnacho font: https://fontsource.org/docs/getting-started/introduction

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/bezhta/entry/Z5oGRwyFntOB03FliwE0 (I used an entry of the Bezhta dictionary as example since we don't have the Wancho dictionary on Dev Env)

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed