### PR TITLE
hide Garifuna local orthography in List View

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/list/ListEntry.svelte
@@ -40,13 +40,15 @@
         <span class="mr-1 hidden sm:inline">[{entry.ph}]</span>
       {/if}
 
-      {#if entry.lo}<i class="mr-1">{entry.lo}</i>{/if}
-      {#if entry.lo2}<i class="mr-1" class:sompeng={dictionary.id === 'sora'}
-          >{entry.lo2}</i
-        >{/if}
-      {#if entry.lo3}<i class="mr-1">{entry.lo3}</i>{/if}
-      {#if entry.lo4}<i class="mr-1">{entry.lo4}</i>{/if}
-      {#if entry.lo5}<i class="mr-1">{entry.lo5}</i>{/if}
+      {#if dictionary.id !== 'garifuna'}
+        {#if entry.lo}<i class="mr-1">{entry.lo}</i>{/if}
+        {#if entry.lo2}<i class="mr-1" class:sompeng={dictionary.id === 'sora'}
+            >{entry.lo2}</i
+          >{/if}
+        {#if entry.lo3}<i class="mr-1">{entry.lo3}</i>{/if}
+        {#if entry.lo4}<i class="mr-1">{entry.lo4}</i>{/if}
+        {#if entry.lo5}<i class="mr-1">{entry.lo5}</i>{/if}
+      {/if}
     </div>
     <div class="flex flex-wrap items-center justify-end -mb-1">
       <div class="text-xs text-gray-600 mr-auto mb-1">


### PR DESCRIPTION
#### Relevant Issue

#### Summarize what changed in this PR (for developers)
Restrict Local orthographies for Garifuna dictionary in list view 

#### How can the changes be tested? 


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed