### PR TITLE
Dialect strings to arrays

### DIFF
--- a/packages/scripts/refactor/entry-refactor.ts
+++ b/packages/scripts/refactor/entry-refactor.ts
@@ -1,8 +1,9 @@
- 
+
 import { IEntry } from '@living-dictionaries/types';
 import { db } from '../config';
 import { program } from 'commander';
 import { reverse_semantic_domains_mapping } from './reverse-semantic-domains-mapping';
+import { turn_dialect_strings_to_arrays } from './turn-dialects-to-arrays';
 program
   //   .version('0.0.1')
   .option('--id <value>', 'Dictionary Id')
@@ -42,9 +43,26 @@ async function fetchEntries(dictionaryId: string) {
     // await refactorGloss(dictionaryId, entry);
     // await notesToPluralForm(dictionaryId, entry);
     // turnPOSintoArray(dictionaryId, entry); // not awaiting so operations can run in parallel otherwise the function errors after about 1400 iterations
-    reverese_semantic_domains_in_db(dictionaryId, entry);
+    // reverese_semantic_domains_in_db(dictionaryId, entry);
+    turnDialectsIntoArray(dictionaryId, entry);
   }
 }
+
+const turnDialectsIntoArray = async (dictionaryId: string, entry: IEntry) => {
+  if (entry.di) {
+    console.log('entry dialect before:');
+    console.log(entry.di);
+    if (Array.isArray(entry.di))
+      return true;
+
+    entry.di =  turn_dialect_strings_to_arrays(entry.di);
+    console.log('entry dialect after:');
+    console.log(entry.di);
+    if (!live) return;
+    await db.collection(`dictionaries/${dictionaryId}/words`).doc(entry.id).set(entry);
+  }
+  return true;
+};
 
 const reverese_semantic_domains_in_db = async (dictionaryId: string, entry: IEntry) => {
   if (entry.sdn) {

--- a/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
+++ b/packages/scripts/refactor/reverse-semantic-domains-mapping.ts
@@ -69,11 +69,12 @@ if (import.meta.vitest) {
 }
 
 function update_old_semantic_domains(semantic_domain: string): string {
-  if (semantic_domain === 'States') {
+  if (semantic_domain === 'States')
     return 'States and Characteristics';
-  } else if (semantic_domain === 'Physical Actions and States') {
+
+  if (semantic_domain === 'Physical Actions and States')
     return 'Physical Actions';
-  }
+
   return semantic_domain;
 }
 

--- a/packages/scripts/refactor/turn-dialects-to-arrays.ts
+++ b/packages/scripts/refactor/turn-dialects-to-arrays.ts
@@ -1,12 +1,9 @@
 export function turn_dialect_strings_to_arrays(dialect: string): string[] {
-  if (dialect) {
-    if (dialect.includes(', ')) {
-      const dialects = dialect.split(', ');
-      return dialects;
-    }
-    return [dialect];
+  if (dialect.includes(', ')) {
+    const dialects = dialect.split(', ');
+    return dialects;
   }
-  return [];
+  return [dialect];
 }
 
 
@@ -19,10 +16,6 @@ if (import.meta.vitest) {
     test('turns multiple dialects as a string into an array with multiple elements', () => {
       const dialect = 'east, west, north, south';
       expect(turn_dialect_strings_to_arrays(dialect)).toEqual(['east', 'west', 'north', 'south']);
-    });
-    test('returns an empty array if dialect is an empty string', () => {
-      const dialect = '';
-      expect(turn_dialect_strings_to_arrays(dialect)).toEqual([]);
     });
   });
 }

--- a/packages/scripts/refactor/turn-dialects-to-arrays.ts
+++ b/packages/scripts/refactor/turn-dialects-to-arrays.ts
@@ -1,0 +1,28 @@
+export function turn_dialect_strings_to_arrays(dialect: string): string[] {
+  if (dialect) {
+    if (dialect.includes(', ')) {
+      const dialects = dialect.split(', ');
+      return dialects;
+    }
+    return [dialect];
+  }
+  return [];
+}
+
+
+if (import.meta.vitest) {
+  describe('turn_dialect_strings_to_arrays', () => {
+    test('turns simple dialect string into an array', () => {
+      const dialect = 'east';
+      expect(turn_dialect_strings_to_arrays(dialect)).toEqual(['east']);
+    });
+    test('turns multiple dialects as a string into an array with multiple elements', () => {
+      const dialect = 'east, west, north, south';
+      expect(turn_dialect_strings_to_arrays(dialect)).toEqual(['east', 'west', 'north', 'south']);
+    });
+    test('returns an empty array if dialect is an empty string', () => {
+      const dialect = '';
+      expect(turn_dialect_strings_to_arrays(dialect)).toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
#### Relevant Issue


#### Summarize what changed in this PR (for developers)
Add a script to convert dialect strings to arrays in South Sámi dictionary  

#### How can the changes be tested? 


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [x] Functions
    - [x] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [x] Functions are short and well named
    - [x] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed