### PR TITLE
fix entries with media lengths since they always have one element at …

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/export/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/export/+page.svelte
@@ -34,6 +34,7 @@
 
     const speakers = await fetchSpeakers(expanded_entries);
 
+    // entriesWithImages and entriesWithAudio have always one element at least due to headers
     entriesWithImages = prepareEntriesForCsv(
       expanded_entries.filter((entry) => entry.senses[0].photo_files?.[0]?.fb_storage_path),
       $dictionary,
@@ -69,40 +70,40 @@
       {$_('export.csv_data', { default: 'Data as .CSV' })} ({$_('export.spreadsheet', { default: 'Spreadsheet' })})
     </div>
     <div
-      class="flex items-center mt-2 {entriesWithImages.length
+      class="flex items-center mt-2 {entriesWithImages.length > 1
         ? ''
         : 'opacity-50 cursor-not-allowed'}">
       <input
-        disabled={!entriesWithImages.length}
+        disabled={entriesWithImages.length <= 1}
         id="images"
         type="checkbox"
         bind:checked={includeImages} />
       <label for="images" class="mx-2 block leading-5 text-gray-900">
-        {$_('misc.images', { default: 'Images' })} ({entriesWithImages.length})</label>
+        {$_('misc.images', { default: 'Images' })} ({entriesWithImages.length - 1})</label>
     </div>
     {#if !mounted}
       <p class="text-xs italic text-orange-400 p-2">
         {$_('export.checking_images', { default: 'Checking if image files exist' })}
       </p>
-    {:else if !entriesWithImages.length}
+    {:else if entriesWithImages.length <= 1}
       <p class="text-sm text-red-700 p-3">
         {$_('export.no_images', { default: 'There are no image files' })}
       </p>
     {/if}
 
     <div
-      class="flex items-center mt-2 {entriesWithAudio.length
+      class="flex items-center mt-2 {entriesWithAudio.length > 1
         ? ''
         : 'opacity-50 cursor-not-allowed'}">
       <input id="audio" type="checkbox" bind:checked={includeAudio} />
       <label for="audio" class="mx-2 block leading-5 text-gray-900">
-        {$_('entry.audio', { default: 'Audio' })} ({entriesWithAudio.length})</label>
+        {$_('entry.audio', { default: 'Audio' })} ({entriesWithAudio.length - 1})</label>
     </div>
     {#if !mounted}
       <p class="text-xs italic text-orange-400 p-2">
         {$_('export.checking_audios', { default: 'Checking if audio files exist' })}
       </p>
-    {:else if !entriesWithAudio.length}
+    {:else if entriesWithAudio.length <= 1}
       <p class="text-sm text-red-700 p-3">
         {$_('export.no_audios', { default: 'There are no audio files' })}
       </p>
@@ -156,7 +157,7 @@
 {#if $admin}
   <div class="mt-5">
     <Button form="filled" href="entries/print"
-      >{$_('export.download_pdf', { default: 'Download PDF' })}</Button>
+    >{$_('export.download_pdf', { default: 'Download PDF' })}</Button>
   </div>
 {/if}
 


### PR DESCRIPTION
…least due to headers

#### Relevant Issue


#### Summarize what changed in this PR (for developers)
Entries with media always showed one more element since prepareEntriesForCsv always return the headers (at least one element)

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/apatani/export

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed