### PR TITLE
convert and expand entries to correctly show and select fields

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/print/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/+page.svelte
@@ -106,7 +106,7 @@
             max="100"
             bind:value={$imagePercent} /><span class="font-medium text-gray-700">%</span>
         </div>
-        <PrintFieldCheckboxes {entries} {preferredPrintFields} {showLabels} {showQrCode} />
+        <PrintFieldCheckboxes entries={entries.map(convert_and_expand_entry)} {preferredPrintFields} {showLabels} {showQrCode} />
       </div>
     </div>
 

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
@@ -2,7 +2,6 @@
   import type { Readable } from 'svelte/store';
   import { t } from 'svelte-i18n';
   import { StandardPrintFields, type ExpandedEntry, type IPrintFields } from '@living-dictionaries/types';
-  import { convert_and_expand_entry } from '$lib/transformers/convert_and_expand_entry';
 
   export let entries: ExpandedEntry[];
   export let preferredPrintFields: Readable<IPrintFields>;
@@ -10,15 +9,14 @@
   export let showQrCode: Readable<boolean>;
 
   $: fieldsThatExist = Object.keys($preferredPrintFields).filter((field) => {
+    if (field === 'gloss') return true;
     return entries.find((entry) => {
-      entry = convert_and_expand_entry(entry);
-      if (field === 'gloss' && entry.senses?.[0].glosses) return true;
-      if (field === 'alternateOrthographies' && entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5)
-        return true;
-      if (field === 'example_sentence'&& entry.senses?.[0].example_sentences?.length) return true;
-      if (field === 'sdn' && entry.senses?.[0].ld_semantic_domains_keys?.length) return true;
-      if (field === 'image' && entry.senses?.[0].photo_files?.length) return true;
-      if (field === 'speaker' && (entry.sound_files?.[0].speakerName || entry.sound_files?.[0].speaker_ids?.length)) return true;
+      if (field === 'alternateOrthographies')
+        return entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5;
+      if (field === 'example_sentence') return entry.senses?.[0].example_sentences?.length;
+      if (field === 'sdn') return entry.senses?.[0].ld_semantic_domains_keys?.length;
+      if (field === 'image') return entry.senses?.[0].photo_files?.length;
+      if (field === 'speaker') return entry.sound_files?.[0].speakerName || entry.sound_files?.[0].speaker_ids?.length;
       return entry[field];
     });
   });

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
@@ -2,6 +2,7 @@
   import type { Readable } from 'svelte/store';
   import { t } from 'svelte-i18n';
   import { StandardPrintFields, type ExpandedEntry, type IPrintFields } from '@living-dictionaries/types';
+  import { convert_and_expand_entry } from '$lib/transformers/convert_and_expand_entry';
 
   export let entries: ExpandedEntry[];
   export let preferredPrintFields: Readable<IPrintFields>;
@@ -9,14 +10,15 @@
   export let showQrCode: Readable<boolean>;
 
   $: fieldsThatExist = Object.keys($preferredPrintFields).filter((field) => {
-    if (field === 'gloss') return true;
     return entries.find((entry) => {
-      if (field === 'alternateOrthographies')
-        return entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5;
-      if (field === 'example_sentence') return entry.senses?.[0].example_sentences?.length;
-      if (field === 'sdn') return entry.senses?.[0].ld_semantic_domains_keys?.length;
-      if (field === 'image') return entry.senses?.[0].photo_files?.length;
-      if (field === 'speaker') return entry.sound_files?.[0].speakerName || entry.sound_files?.[0].speaker_ids?.length;
+      entry = convert_and_expand_entry(entry);
+      if (field === 'gloss' && entry.senses?.[0].glosses) return true;
+      if (field === 'alternateOrthographies' && entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5)
+        return true;
+      if (field === 'example_sentence'&& entry.senses?.[0].example_sentences?.length) return true;
+      if (field === 'sdn' && entry.senses?.[0].ld_semantic_domains_keys?.length) return true;
+      if (field === 'image' && entry.senses?.[0].photo_files?.length) return true;
+      if (field === 'speaker' && (entry.sound_files?.[0].speakerName || entry.sound_files?.[0].speaker_ids?.length)) return true;
       return entry[field];
     });
   });

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
@@ -8,7 +8,7 @@
   export let showLabels: Readable<boolean>;
   export let showQrCode: Readable<boolean>;
 
-  $: fieldsThatExist = Object.keys($preferredPrintFields).filter((field) => {
+  $: fieldsThatExist = (Object.keys($preferredPrintFields) as (keyof IPrintFields)[]).filter((field) => {
     if (field === 'gloss') return true;
     return entries.find((entry) => {
       if (field === 'alternateOrthographies')


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #355 

#### Summarize what changed in this PR (for developers)
I modified the PrintFieldCheckboxes component using the convert_and_expand_entry function and changed the logic of the fieldsThatExist dynamic variable.

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/muniche/entries/print

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed