### PR TITLE
Entry back button

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -9,37 +9,34 @@
   import { seo_description } from './seo_description';
   import { convert_and_expand_entry } from '$lib/transformers/convert_and_expand_entry';
   import { navigating } from '$app/stores';
-  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
 
   export let data;
-  $: ({ admin,
+  $: ({
+    admin,
     algoliaQueryParams,
     canEdit,
     dictionary,
     isContributor,
     isManager,
     user,
-    initialEntry } = data);
+    initialEntry,
+  } = data);
 
   $: entry = $locale && convert_and_expand_entry($initialEntry); // adding locale triggers update of translated semantic domains and parts of speech
-  if ($navigating?.from.url.href)
-    localStorage.setItem('last_href_visited', $navigating.from.url.href);
-
+  let backUrl: string;
+  onMount(() => {
+    backUrl = $navigating?.from?.url.href
+      ? `${$navigating.from.url.href}${$algoliaQueryParams}`
+      : `/${$dictionary.id}/entries/list${$algoliaQueryParams}`;
+  });
 </script>
 
 <div
   class="flex justify-between items-center mb-3 md:top-12 sticky top-0 z-30
-    bg-white pt-1 -mt-1">
-  <Button
-    class="-ml-2 !px-2"
-    color="black"
-    form="simple"
-    onclick={() => {
-      if (localStorage.getItem('last_href_visited'))
-        goto(localStorage.getItem('last_href_visited'));
-      else
-        goto(`/${$dictionary.id}/entries/list${$algoliaQueryParams}`);
-    }}>
+    bg-white pt-1 -mt-1"
+>
+  <Button class="-ml-2 !px-2" color="black" form="simple" href={backUrl}>
     <i class="fas fa-arrow-left rtl-x-flip" />
     {$t('misc.back', { default: 'Back' })}
   </Button>
@@ -52,7 +49,9 @@
       <Button
         color="red"
         form="simple"
-        onclick={() => deleteEntry($initialEntry, $dictionary.id, $algoliaQueryParams)}>
+        onclick={() =>
+          deleteEntry($initialEntry, $dictionary.id, $algoliaQueryParams)}
+      >
         <span class="hidden md:inline">
           {$t('misc.delete', { default: 'Delete' })}
         </span>
@@ -73,7 +72,14 @@
   canEdit={$canEdit}
   on:deleteImage={() => deleteImage(entry, $dictionary.id)}
   on:deleteVideo={() => deleteVideo(entry, $dictionary.id)}
-  on:valueupdate={({detail: { field, newValue}}) => saveUpdateToFirestore({field, value: newValue, entryId: entry.id, dictionaryId: $dictionary.id})} />
+  on:valueupdate={({ detail: { field, newValue } }) =>
+    saveUpdateToFirestore({
+      field,
+      value: newValue,
+      entryId: entry.id,
+      dictionaryId: $dictionary.id,
+    })}
+/>
 
 <SeoMetaTags
   imageTitle={entry.lx}
@@ -83,4 +89,5 @@
   lng={$dictionary.coordinates?.longitude}
   url="https://livingdictionaries.app/{$dictionary.id}/entry/{entry.id}"
   gcsPath={entry.senses?.[0]?.photo_files?.[0]?.specifiable_image_url}
-  keywords="Minority Languages, Indigenous Languages, Language Documentation, Dictionary, Minority Community, Language Analysis, Language Education, Endangered Languages, Language Revitalization, Linguistics, Word Lists, Linguistic Analysis, Dictionaries, Living Dictionaries, Living Tongues, Under-represented Languages, Tech Resources, Language Sustainability, Language Resources, Diaspora Languages, Elicitation, Language Archives, Ancient Languages, World Languages, Obscure Languages, Little Known languages, Digital Dictionary, Dictionary Software, Free Software, Online Dictionary Builder" />
+  keywords="Minority Languages, Indigenous Languages, Language Documentation, Dictionary, Minority Community, Language Analysis, Language Education, Endangered Languages, Language Revitalization, Linguistics, Word Lists, Linguistic Analysis, Dictionaries, Living Dictionaries, Living Tongues, Under-represented Languages, Tech Resources, Language Sustainability, Language Resources, Diaspora Languages, Elicitation, Language Archives, Ancient Languages, World Languages, Obscure Languages, Little Known languages, Digital Dictionary, Dictionary Software, Free Software, Online Dictionary Builder"
+/>

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -34,7 +34,12 @@
     class="-ml-2 !px-2"
     color="black"
     form="simple"
-    onclick={() => goto(localStorage.getItem('last_href_visited'))}>
+    onclick={() => {
+      if (localStorage.getItem('last_href_visited'))
+        goto(localStorage.getItem('last_href_visited'));
+      else
+        goto(`/${$dictionary.id}/entries/list${$algoliaQueryParams}`);
+    }}>
     <i class="fas fa-arrow-left rtl-x-flip" />
     {$t('misc.back', { default: 'Back' })}
   </Button>

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -8,6 +8,7 @@
   import SeoMetaTags from '$lib/components/SeoMetaTags.svelte';
   import { seo_description } from './seo_description';
   import { convert_and_expand_entry } from '$lib/transformers/convert_and_expand_entry';
+  import { navigating } from '$app/stores';
 
   export let data;
   $: ({ admin,
@@ -20,6 +21,8 @@
     initialEntry } = data);
 
   $: entry = $locale && convert_and_expand_entry($initialEntry); // adding locale triggers update of translated semantic domains and parts of speech
+
+  localStorage.setItem('last_href_visited', $navigating?.from.url.href);
 </script>
 
 <div
@@ -29,7 +32,7 @@
     class="-ml-2 !px-2"
     color="black"
     form="simple"
-    href="/{$dictionary.id}/entries/list{$algoliaQueryParams}">
+    href={localStorage.getItem('last_href_visited')}>
     <i class="fas fa-arrow-left rtl-x-flip" />
     {$t('misc.back', { default: 'Back' })}
   </Button>

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -9,6 +9,7 @@
   import { seo_description } from './seo_description';
   import { convert_and_expand_entry } from '$lib/transformers/convert_and_expand_entry';
   import { navigating } from '$app/stores';
+  import { goto } from '$app/navigation';
 
   export let data;
   $: ({ admin,
@@ -21,8 +22,9 @@
     initialEntry } = data);
 
   $: entry = $locale && convert_and_expand_entry($initialEntry); // adding locale triggers update of translated semantic domains and parts of speech
+  if ($navigating?.from.url.href)
+    localStorage.setItem('last_href_visited', $navigating.from.url.href);
 
-  localStorage.setItem('last_href_visited', $navigating?.from.url.href);
 </script>
 
 <div
@@ -32,7 +34,7 @@
     class="-ml-2 !px-2"
     color="black"
     form="simple"
-    href={localStorage.getItem('last_href_visited')}>
+    onclick={() => goto(localStorage.getItem('last_href_visited'))}>
     <i class="fas fa-arrow-left rtl-x-flip" />
     {$t('misc.back', { default: 'Back' })}
   </Button>


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #290 

#### Summarize what changed in this PR (for developers)
Use `$navigation` from sveltekit modules and saving navigation from data to localStorage to navigate with `goto` to the last hypertext reference visited.

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/apatani/entries/list
/apatani/entries/gallery?entries_prod%5Btoggle%5D%5BhasImage%5D=true

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed