### PR TITLE
add Entry Count column to List of Dictionaries table and to the CSV d…

### DIFF
--- a/packages/site/src/lib/export/__snapshots__/prepareDictionariesForCsv.test.ts.snap
+++ b/packages/site/src/lib/export/__snapshots__/prepareDictionariesForCsv.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`prepareDictionaryForCsv > dictionary example 1 1`] = `
 {
+  "entry_count": 0,
   "glottocode": "badh1238",
   "iso6393": "",
   "latitude": 30.133,
@@ -16,6 +17,7 @@ exports[`prepareDictionaryForCsv > dictionary example 1 1`] = `
 
 exports[`prepareDictionaryForCsv > dictionary example 2 1`] = `
 {
+  "entry_count": 1,
   "glottocode": "buri1258",
   "iso6393": "bua",
   "latitude": 51.833,
@@ -30,6 +32,7 @@ exports[`prepareDictionaryForCsv > dictionary example 2 1`] = `
 
 exports[`prepareDictionaryForCsv > dictionary example 3 1`] = `
 {
+  "entry_count": 1,
   "glottocode": undefined,
   "iso6393": undefined,
   "latitude": undefined,

--- a/packages/site/src/lib/export/prepareDictionariesForCsv.ts
+++ b/packages/site/src/lib/export/prepareDictionariesForCsv.ts
@@ -4,6 +4,7 @@ import type { Timestamp } from 'firebase/firestore';
 enum StandardDictionaryCSVFields {
   name = 'Dictionary Name',
   public = 'Public',
+  entry_count = 'Entry Count',
   url = 'URL',
   iso6393 = 'ISO 639-3',
   glottocode = 'Glottocode',
@@ -29,6 +30,7 @@ export function prepareDictionaryForCsv(dictionary: IDictionary): StandardDictio
   return {
     name: dictionary.name.replace(/,/g, '_'),
     public: dictionary.public,
+    entry_count: dictionary.entryCount,
     url: dictionary.url || create_dictionary_url(dictionary.id),
     iso6393: dictionary.iso6393,
     glottocode: dictionary.glottocode,

--- a/packages/site/src/lib/export/prepareDictionariesForCsv.ts
+++ b/packages/site/src/lib/export/prepareDictionariesForCsv.ts
@@ -30,7 +30,7 @@ export function prepareDictionaryForCsv(dictionary: IDictionary): StandardDictio
   return {
     name: dictionary.name.replace(/,/g, '_'),
     public: dictionary.public,
-    entry_count: dictionary.entryCount,
+    entry_count: dictionary.url?.startsWith('http://talkingdictionary') ? '' : dictionary.entryCount,
     url: dictionary.url || create_dictionary_url(dictionary.id),
     iso6393: dictionary.iso6393,
     glottocode: dictionary.glottocode,

--- a/packages/site/src/routes/dictionaries/+page.svelte
+++ b/packages/site/src/routes/dictionaries/+page.svelte
@@ -76,8 +76,8 @@
           <td class="font-semibold">
             <a href={dictionary.url}>{dictionary.name}</a>
           </td>
-          <td class="font-semibold">
-            <p>{dictionary.entryCount}</p>
+          <td>
+            {dictionary.entryCount}
           </td>
           <td class="underline">
             {#if dictionary.url}

--- a/packages/site/src/routes/dictionaries/+page.svelte
+++ b/packages/site/src/routes/dictionaries/+page.svelte
@@ -57,6 +57,7 @@
         <th>
           {$_('dictionary.name_of_language', { default: 'Name of Language' })}
         </th>
+        <th> {$_('about.entry_count', { default: 'Entry Count' })} </th>
         <th> URL </th>
         <th> ISO 639-3 </th>
         <th> Glottocode </th>
@@ -74,6 +75,9 @@
         <tr>
           <td class="font-semibold">
             <a href={dictionary.url}>{dictionary.name}</a>
+          </td>
+          <td class="font-semibold">
+            <p>{dictionary.entryCount}</p>
           </td>
           <td class="underline">
             {#if dictionary.url}

--- a/packages/site/src/routes/dictionaries/+page.svelte
+++ b/packages/site/src/routes/dictionaries/+page.svelte
@@ -77,7 +77,7 @@
             <a href={dictionary.url}>{dictionary.name}</a>
           </td>
           <td>
-            {dictionary.entryCount}
+            {dictionary.url?.startsWith('http://talkingdictionary') ? '' : dictionary.entryCount}
           </td>
           <td class="underline">
             {#if dictionary.url}


### PR DESCRIPTION
…ownload

#### Relevant Issue
One of our partners organizations called Rising Voices is asking for this information for their own directory.

#### Summarize what changed in this PR (for developers)
I added it to the packages\site\src\routes\dictionaries\+page.svelte table and to the packages\site\src\lib\export\prepareDictionariesForCsv.ts -> StandardDictionaryCSVFields enum.

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/dictionaries

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [x] Functions
    - [x] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [x] Functions are short and well named
    - [x] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed