### PR TITLE
Display print improvements

### DIFF
--- a/packages/site/src/lib/mocks/entries.ts
+++ b/packages/site/src/lib/mocks/entries.ts
@@ -53,12 +53,34 @@ const complexData: GoalDatabaseEntry = {
   id: '1', // for table
 }
 
+const hebrewData: GoalDatabaseEntry = {
+  lx: 'אילא',
+  sn: [
+    {
+      gl: {
+        en: 'hand',
+        he: 'יָד'
+      },
+      xs: [
+        {
+          en: 'My hand does not reach.',
+          he: 'הַיָּד שֶׁלִּי לֹא מַגִּיעָה',
+          vn: 'אִילָא דִּידִי לָא מַתְיָא',
+        }
+      ],
+    }
+  ],
+  id: '4', // for table
+}
+
 const t = (({dynamicKey: key}: { dynamicKey: string}) => {
   const [section, item] = key.split('.')
   return en[section][item];
 }) as TranslateFunction
 
 export const complex: ExpandedEntry = expand_entry(complexData, t);
+
+export const hebrew: ExpandedEntry = expand_entry(hebrewData, t);
 
 export const simple: ExpandedEntry = {
   lexeme: 'hello',

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.svelte
@@ -7,7 +7,7 @@
   import { defaultPrintFields } from './printFields';
   import { add_periods_and_comma_separate_parts_of_speech } from '$lib/helpers/entry/add_periods_and_comma_separate_parts_of_speech';
   import { get_local_orthographies } from '$lib/helpers/entry/get_local_orthagraphies';
-  import { spaceSeparateSentences } from './separateSentences';
+  import { slashSeparateSentences } from './separateSentences';
   import { tick } from 'svelte';
 
   export let entry: ExpandedEntry;
@@ -44,12 +44,12 @@
           glosses: sense.glosses,
           dictionary_gloss_languages: dictionary.glossLanguages,
           t: $page.data.t,
-        }).join(', '))}
+        }).join(', '))}{selectedFields.example_sentence && sense.example_sentences?.length > 0 ? ';' : ''}
       </span>
     {/if}
 
     {#if selectedFields.example_sentence}
-      {spaceSeparateSentences(sense.example_sentences)}
+      <i>{slashSeparateSentences(sense.example_sentences)}</i>
     {/if}
 
     {#if selectedFields.semantic_domains}

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.variants.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.variants.ts
@@ -1,7 +1,7 @@
 import type { Variant } from 'kitbook';
 import type Component from './PrintEntry.svelte';
 import type { IPrintFields } from '@living-dictionaries/types';
-import { complex, simple } from '$lib/mocks/entries';
+import { complex, simple, hebrew } from '$lib/mocks/entries';
 import { basic_mock_dictionary } from '$lib/mocks/dictionaries';
 import { defaultPrintFields } from './printFields';
 
@@ -31,6 +31,18 @@ export const variants: Variant<Component>[] = [
       showQrCode: true,
       headwordSize: 20,
       showLabels: true,
+    }
+  },
+  {
+    name: 'example with Hebrew text',
+    description: 'This is an example where non-hebrew characters are mixed with hebrew characters in the same line.',
+    viewports: [{width: 400, height: 100}],
+    languages: [{name: 'english', code: 'en'}, {name: 'hebrew', code: 'he'}],
+    props: {
+      dictionary: basic_mock_dictionary,
+      selectedFields,
+      entry: hebrew,
+      headwordSize: 20,
     }
   },
   {

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
@@ -11,6 +11,7 @@
   $: fieldsThatExist = (Object.keys($preferredPrintFields) as (keyof IPrintFields)[]).filter((field) => {
     if (field === 'gloss') return true;
     return entries.find((entry) => {
+      if (field === 'parts_of_speech') return entry.senses?.[0].parts_of_speech_keys?.length;
       if (field === 'local_orthography')
         return entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5;
       if (field === 'example_sentence') return entry.senses?.[0].example_sentences?.length;

--- a/packages/site/src/routes/[dictionaryId]/entries/print/separateSentences.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/separateSentences.ts
@@ -1,8 +1,8 @@
 import type { IExampleSentence } from '@living-dictionaries/types';
 
-export function spaceSeparateSentences(sentences: IExampleSentence[]): string {
+export function slashSeparateSentences(sentences: IExampleSentence[]): string {
   if (!sentences) return '';
-  return sentences.map((sentence) => Object.values(sortVernacularFirst(sentence)).join(' ')).join(' ');
+  return sentences.map((sentence) => Object.values(sortVernacularFirst(sentence)).join(' / ')).join(' ');
 }
 
 export function sortVernacularFirst(example_sentence: IExampleSentence) {
@@ -19,10 +19,10 @@ export function sortVernacularFirst(example_sentence: IExampleSentence) {
 }
 
 if (import.meta.vitest) {
-  describe(spaceSeparateSentences, () => {
+  describe(slashSeparateSentences, () => {
     it('should return an empty string when given an empty array', () => {
-      expect(spaceSeparateSentences([])).toBe('');
-      expect(spaceSeparateSentences(null)).toBe('');
+      expect(slashSeparateSentences([])).toBe('');
+      expect(slashSeparateSentences(null)).toBe('');
     });
 
     it('should return a string with sentences separated by spaces', () => {
@@ -38,8 +38,8 @@ if (import.meta.vitest) {
           es: 'Esta es la segunda oración.'
         },
       ];
-      expect(spaceSeparateSentences(sentences)).toBe(
-        'Prima lexema sententia. This is the first sentence. Esta es la primer oración. Secunda lexema sententia. This is the second sentence. Esta es la segunda oración.'
+      expect(slashSeparateSentences(sentences)).toBe(
+        'Prima lexema sententia. / This is the first sentence. / Esta es la primer oración. Secunda lexema sententia. / This is the second sentence. / Esta es la segunda oración.'
       );
     });
   });


### PR DESCRIPTION
#### Relevant Issue
New requirements or Print view


#### Summarize what changed in this PR (for developers)

- [ ] we need a semi-colon “;” following the translations
- [ ] vernacular sample sentence should be stylized in italics.
- [ ] add a slash “/” between each sample sentence so that they are at least separated. that way we don’t have add extra punctuation that might be problematic in some way

#### How can the changes be tested? 
/jewish-neo-aramaic/entries/print
/kitbook/routes/[dictionaryId]/entries/print/PrintEntry


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed