### PR TITLE
add noun class checkbox to print view

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.variants.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintEntry.variants.ts
@@ -34,6 +34,18 @@ export const variants: Variant<Component>[] = [
     }
   },
   {
+    name: 'complex without labels',
+    viewports: [{width: 400, height: 700}],
+    props: {
+      dictionary: basic_mock_dictionary,
+      selectedFields,
+      entry: complex,
+      showQrCode: true,
+      headwordSize: 20,
+      showLabels: false,
+    }
+  },
+  {
     name: 'example with Hebrew text',
     description: 'This is an example where non-hebrew characters are mixed with hebrew characters in the same line.',
     viewports: [{width: 400, height: 100}],

--- a/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/print/PrintFieldCheckboxes.svelte
@@ -16,6 +16,7 @@
         return entry.local_orthography_1 || entry.local_orthography_2 || entry.local_orthography_3 || entry.local_orthography_4 || entry.local_orthography_5;
       if (field === 'example_sentence') return entry.senses?.[0].example_sentences?.length;
       if (field === 'semantic_domains') return entry.senses?.[0].ld_semantic_domains_keys?.length;
+      if (field === 'noun_class') return entry.senses?.[0].noun_class;
       if (field === 'photo') return entry.senses?.[0].photo_files?.length;
       if (field === 'speaker') return entry.sound_files?.[0].speakerName || entry.sound_files?.[0].speaker_ids?.length;
       return entry[field];

--- a/packages/types/print-entry.interface.ts
+++ b/packages/types/print-entry.interface.ts
@@ -20,6 +20,7 @@ export enum StandardPrintFields {
   morphology = 'Morphology',
   plural_form = 'Plural Form',
   variant = 'Variant',
+  noun_class = 'Noun Class',
   dialects = 'Dialects',
   notes = 'Notes',
 }


### PR DESCRIPTION
#### Relevant Issue
PhD Pam Munro suggested to add noun class data to our print view.

#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.
/kitbook/routes/[dictionaryId]/entries/print/PrintEntry

#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed