### PR TITLE
remove problematic mac chrome fonts

### DIFF
--- a/packages/site/src/routes/global.css
+++ b/packages/site/src/routes/global.css
@@ -8,10 +8,27 @@ select {
   print-color-adjust: exact;
 }
 
+/* Use Doulos SIL if IPA contexts if ever needed */
 html {
-  /* TODO: comb through and select what we actually want */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Noto Sans Wancho", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; 
+  font-family: 
+  "Segoe UI", /* This does not show up in Mac Chrome, but it does on Windows and is nice - keep it  */
+  Arial, /* Is on Mac Chrome and it is correct, but the font in general, while it works, is not too pleasing. */ 
+  "Noto Sans", 
+  "Noto Sans Wancho", /* Noto Sans fonts are in place to catch missing glyphs that other fonts don't provide - we aren't presently loading these, but just provide a reference if a user happens to have them. They are a useful font-family to specifically load in future if coming across missing glyph issues */
+  sans-serif, /* Fallback. On Mac Chrome displays Helvetica - Diacritis are in the right spot horizontally but they stack vertically on top of things like a dotted i instead of replacing the dot */
+  
+  /* Emoji catch-alls */
+  "Apple Color Emoji", 
+  "Segoe UI Emoji", 
+  "Segoe UI Symbol", 
+  "Noto Color Emoji"; 
 }
+/* Problematic Mac Chrome fonts */
+/* ui-sans-serif, this tries to use the font used by the browser's default UI sans-serif font, which for Mac Chrome is .SF NS - the font which causes diacritics display issues */
+/* system-ui, same problem as ui-sans-serif */
+/* -apple-system, same problem ui-sans-serif */
+/* BlinkMacSystemFont, same problem ui-sans-serif */
+/* "Helvetica Neue", After removing the above fonts which default to Mac Chrome's SF NS, then Mac Chrome shows this and it also shows diacritics wrong */
 
 
 [dir='rtl'] .rtl-x-flip {


### PR DESCRIPTION
Removes fonts that default to ".SF NS" font on Mac Chrome which displays diacritics improperly to the right. Fixes #360 

Used https://www.lambdatest.com to debug ($9/mo for Mac machines, cheaper than Browserstack)

https://app-beta.lambdatest.com/console/realtime/browser/desktop