### PR TITLE
fix admin buttons visibility

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/contributors/Partners.svelte
+++ b/packages/site/src/routes/[dictionaryId]/contributors/Partners.svelte
@@ -36,7 +36,7 @@
       <div class="text-sm leading-5 font-medium text-gray-900">
         Living Tongues Institute for Endangered Languages
       </div>
-      {#if admin > 1}
+      {#if admin}
         <div class="w-1" />
         <Button
           color="red"
@@ -53,7 +53,7 @@
         alt="Living Tongues Institute for Endangered Languages"
         src={LIVING_TONGUES_LOGO} />
     </div>
-  {:else if can_edit}
+  {:else if admin}
     <Button
       onclick={async () => {
         await hide_living_tongues_logo(false);

--- a/packages/site/src/routes/[dictionaryId]/contributors/Partners.variants.ts
+++ b/packages/site/src/routes/[dictionaryId]/contributors/Partners.variants.ts
@@ -52,6 +52,25 @@ const partners = [
 
 export const variants: Variant<Component>[] = [
   {
+    name: 'only admin',
+    props: {
+      admin: 1,
+      can_edit: true,
+      partners,
+      ...edits,
+    },
+  },
+  {
+    name: 'only admin without Living Tongues logo',
+    props: {
+      hideLivingTonguesLogo: true,
+      admin: 1,
+      can_edit: true,
+      partners,
+      ...edits,
+    },
+  },
+  {
     name: 'can edit',
     props: {
       can_edit: true,
@@ -62,6 +81,14 @@ export const variants: Variant<Component>[] = [
   {
     name: 'viewer',
     props: {
+      partners,
+      ...edits,
+    },
+  },
+  {
+    name: 'viewer without Living Tongues logo',
+    props: {
+      hideLivingTonguesLogo: true,
       partners,
       ...edits,
     },


### PR DESCRIPTION
Only admins from Living Dictionaries must add or remove Living Tongues name and Logo 