### PR TITLE
Change email notifications

### DIFF
--- a/packages/site/src/lib/components/modals/Contact.svelte
+++ b/packages/site/src/lib/components/modals/Contact.svelte
@@ -165,8 +165,8 @@
   {:else if status == 'fail'}
     <h4 class="text-xl mt-1 mb-4">
       {$page.data.t('contact.message_failed')}
-      <a class="underline ml-1" href="mailto:annaluisa@livingtongues.org">
-        annaluisa@livingtongues.org
+      <a class="underline ml-1" href="mailto:dictionaries@livingtongues.org">
+        dictionaries@livingtongues.org
       </a>
     </h4>
   {/if}

--- a/packages/site/src/routes/+layout.svelte
+++ b/packages/site/src/routes/+layout.svelte
@@ -3,18 +3,11 @@
   import { navigating, page } from '$app/stores';
   import { browser } from '$app/environment';
   import LoadingIndicator from './LoadingIndicator.svelte';
-
-  let hideMessage = false;
 </script>
 
 {#if browser && $navigating}
   <LoadingIndicator />
 {/if}
-
-<div class:hidden={hideMessage} class="bg-amber-400 pl-4 sticky top-0 z-10 md:text-sm text-xs">
-  <span class="cursor-pointer" on:click={() => hideMessage = true}>&times;</span>
-  <strong>Attention:</strong> New dictionary entries are not being displayed correctly at this time. This will be resolved on February 15, 2024. We apologize for the inconvenience.
-</div>
 
 <div id="direction" dir={$page.data.t('page.direction')}>
   <slot />

--- a/packages/site/src/routes/api/email/addresses.ts
+++ b/packages/site/src/routes/api/email/addresses.ts
@@ -7,7 +7,7 @@ export const noReplyAddress = {
   name: 'Living Tongues Institute for Endangered Languages',
 };
 
-export const annaAddress = { email: 'annaluisa@livingtongues.org' };
+export const officialAddress = { email: 'dictionaries@livingtongues.org' };
 const gregAddress = { email: 'livingtongues@gmail.com' };
 
 export function getAdminRecipients(initiatorEmail: string): Address[] {
@@ -25,7 +25,7 @@ export function getAdminRecipients(initiatorEmail: string): Address[] {
 
   return [
     ...recipients,
-    annaAddress,
+    officialAddress,
     gregAddress,
   ];
 }
@@ -41,6 +41,6 @@ export function getSupportMessageRecipients({ dev }: { dev: boolean }): Address[
 
   return [
     ...recipients,
-    annaAddress,
+    officialAddress,
   ];
 }

--- a/packages/site/src/routes/api/email/send/+server.ts
+++ b/packages/site/src/routes/api/email/send/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { sendEmail } from './mailChannels';
 import type { EmailParts, MailChannelsSendBody } from './mail-channels.interface';
 import { DKIM_PRIVATE_KEY, SEND_EMAIL_KEY } from '$env/static/private';
-import { annaAddress, noReplyAddress } from '../addresses';
+import { officialAddress, noReplyAddress } from '../addresses';
 import { ResponseCodes } from '$lib/constants';
 
 export interface SendRequestBody {
@@ -27,7 +27,7 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
         dkim_private_key: DKIM_PRIVATE_KEY,
       }],
       from: noReplyAddress,
-      reply_to: reply_to || annaAddress,
+      reply_to: reply_to || officialAddress,
       subject,
       content: [{
         type,

--- a/packages/site/src/routes/api/email/send/mailChannels.manual-send.ts
+++ b/packages/site/src/routes/api/email/send/mailChannels.manual-send.ts
@@ -29,7 +29,7 @@
 //           dkim_private_key: DKIM_PRIVATE_KEY,
 //         }],
 //         from,
-//         reply_to: { email: 'annaluisa@livingtongues.org' },
+//         reply_to: { email: 'dictionaries@livingtongues.org' },
 //         subject: 'Living Dictionaries - News and Numbers from 2023',
 //         content: [{
 //           type: 'text/html',


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
#423 

#### Summarize what changed in this PR (for developers)
Set new official and centralized email account:  [dictionaries@livingtongues.org](mailto:dictionaries@livingtongues.org)
