### PR TITLE
fix media uploads

### DIFF
--- a/packages/site/src/lib/components/audio/EditAudio.svelte
+++ b/packages/site/src/lib/components/audio/EditAudio.svelte
@@ -13,7 +13,7 @@
 
   export let entry: ExpandedEntry;
   export let sound_file: ExpandedAudio;
-  $: ({ dictionary, admin, speakers } = $page.data)
+  $: ({ dictionary, admin, speakers, user } = $page.data)
 
   let readyToRecord: boolean;
   let showUploadAudio = true;
@@ -58,6 +58,7 @@
   }
 </script>
 
+
 <Modal on:close>
   <span slot="heading"> <span class="i-material-symbols-hearing text-lg text-sm" /> {entry.lexeme} </span>
 
@@ -88,6 +89,8 @@
           {#if showUploadAudio}
             {#await import('$lib/components/audio/UploadAudio.svelte') then { default: UploadAudio }}
               <UploadAudio
+                dictionary_id={$dictionary.id}
+                user={$user}
                 file={file || audioBlob}
                 entryId={entry.id}
                 {speakerId}

--- a/packages/site/src/lib/components/audio/UploadAudio.svelte
+++ b/packages/site/src/lib/components/audio/UploadAudio.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import type { GoalDatabaseAudio, GoalDatabaseEntry } from '@living-dictionaries/types';
+  import type { GoalDatabaseAudio, GoalDatabaseEntry, IUser } from '@living-dictionaries/types';
   import { updateOnline } from 'sveltefirets';
   import { getStorage, ref, uploadBytesResumable } from 'firebase/storage';
   import { tweened } from 'svelte/motion';
@@ -9,7 +9,8 @@
   export let file: File | Blob;
   export let entryId: string;
   export let speakerId: string;
-  $: ({dictionary, user} = $page.data)
+  export let dictionary_id: string;
+  export let user: IUser;
 
   const progress = tweened(0, {
     duration: 2000,
@@ -25,13 +26,14 @@
 
 
   function startUpload() {
+
     // const _dictName = dictionary.name.replace(/\s+/g, '_');
     // const _lexeme = lexeme.replace(/\s+/g, '_');
     const fileTypeSuffix = file.type.split('/')[1];
 
     // const storagePath = `${_dictName}_${dictionary.id}/audio/{_lexeme}_${entryId}_${new Date().getTime()}.${fileTypeSuffix}`;
-    const storagePath = `${$dictionary.id}/audio/${entryId}_${new Date().getTime()}.${fileTypeSuffix}`;
-    const customMetadata = { uploadedBy: $user.displayName };
+    const storagePath = `${dictionary_id}/audio/${entryId}_${new Date().getTime()}.${fileTypeSuffix}`;
+    const customMetadata = { uploadedBy: user.displayName };
 
     // https://firebase.google.com/docs/storage/web/upload-files
     const storage = getStorage();
@@ -76,12 +78,12 @@
           const sf: GoalDatabaseAudio = {
             path: storagePath,
             ts: new Date().getTime(),
-            ab: $user.uid,
+            ab: user.uid,
             sp: [speakerId],
           };
 
           await updateOnline<GoalDatabaseEntry>(
-            `dictionaries/${$dictionary.id}/words/${entryId}`,
+            `dictionaries/${dictionary_id}/words/${entryId}`,
             { sfs: [sf] },
             { abbreviate: true }
           );

--- a/packages/site/src/lib/components/image/UploadImage.svelte
+++ b/packages/site/src/lib/components/image/UploadImage.svelte
@@ -8,11 +8,11 @@
   import { get } from 'svelte/store';
   import { createEventDispatcher, onMount } from 'svelte';
   import { post_request } from '$lib/helpers/get-post-requests';
+  import type { IUser } from '@living-dictionaries/types';
 
   export let file: File;
   export let fileLocationPrefix: string;
-  $: ({user} = $page.data)
-
+  export let user: IUser;
 
   const progress = tweened(0, {
     duration: 2000,
@@ -34,7 +34,7 @@
 
   function startUpload(storagePath: string) {
     const customMetadata = {
-      uploadedBy: $user.displayName,
+      uploadedBy: user.displayName,
       originalFileName: file.name,
     };
 

--- a/packages/site/src/lib/components/video/AddVideo.svelte
+++ b/packages/site/src/lib/components/video/AddVideo.svelte
@@ -11,7 +11,7 @@
   import { createEventDispatcher } from 'svelte';
   import { expand_video } from '$lib/transformers/expand_entry';
 
-  $: ({dictionary, speakers} = $page.data)
+  $: ({dictionary, speakers, user} = $page.data)
   const dispatch = createEventDispatcher();
   const close = () => dispatch('close');
 
@@ -44,7 +44,7 @@
 
           <SelectVideo let:file>
             {#await import('$lib/components/video/UploadVideo.svelte') then { default: UploadVideo }}
-              <UploadVideo {file} entryId={entry.id} {speakerId} />
+              <UploadVideo dictionary_id={$dictionary.id} user={$user} {file} entryId={entry.id} {speakerId} />
             {/await}
           </SelectVideo>
 
@@ -66,7 +66,7 @@
                 </div>
               {:else}
                 {#await import('$lib/components/video/UploadVideo.svelte') then { default: UploadVideo }}
-                  <UploadVideo file={videoBlob} entryId={entry.id} {speakerId} />
+                  <UploadVideo dictionary_id={$dictionary.id} user={$user} file={videoBlob} entryId={entry.id} {speakerId} />
                 {/await}
               {/if}
             </ShowHide>

--- a/packages/site/src/lib/components/video/UploadVideo.svelte
+++ b/packages/site/src/lib/components/video/UploadVideo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { page } from '$app/stores';
-  import type { GoalDatabaseVideo, IVideoCustomMetadata } from '@living-dictionaries/types';
+  import type { GoalDatabaseVideo, IUser, IVideoCustomMetadata } from '@living-dictionaries/types';
   import { getStorage, ref, uploadBytesResumable, type TaskState, type UploadTask, StorageError } from 'firebase/storage';
   import { addVideo } from '$lib/helpers/media/update';
   import { tweened } from 'svelte/motion';
@@ -10,7 +10,8 @@
   export let file: File | Blob
   export let entryId: string
   export let speakerId: string;
-  $: ({dictionary, user} = $page.data)
+  export let dictionary_id: string;
+  export let user: IUser;
 
   let uploadTask: UploadTask;
   let taskState: TaskState;
@@ -27,11 +28,11 @@
 
     const fileTypeSuffix = file.type.split('/')[1].split(';')[0]; // turns 'video/webm;codecs=vp8,opus' to 'webm' and 'video/mp4' to 'mp4'
 
-    const storagePath = `${$dictionary.id}/videos/${entryId}_${new Date().getTime()}.${fileTypeSuffix}`;
+    const storagePath = `${dictionary_id}/videos/${entryId}_${new Date().getTime()}.${fileTypeSuffix}`;
 
     const customMetadata: IVideoCustomMetadata & Record<string, string> = {
-      uploadedByUid: $user.uid,
-      uploadedByName: $user.displayName,
+      uploadedByUid: user.uid,
+      uploadedByName: user.displayName,
     };
 
     // https://firebase.google.com/docs/storage/web/upload-files
@@ -53,10 +54,10 @@
         try {
           const database_video: GoalDatabaseVideo = {
             path: storagePath,
-            ab: $user.uid,
+            ab: user.uid,
             sp: [speakerId],
           };
-          await addVideo(entryId, $dictionary.id, database_video);
+          await addVideo(entryId, dictionary_id, database_video);
 
           success = true;
         } catch (err) {

--- a/packages/site/src/routes/[dictionaryId]/entries-local/EntryFilters.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries-local/EntryFilters.svelte
@@ -59,7 +59,7 @@
             {search_params}
             search_param_key="speakers"
             values={result_facets.speakers.values}
-            speaker_ids_to_names={speakers.reduce((acc, speaker) => {
+            speaker_ids_to_names={speakers?.reduce((acc, speaker) => {
               acc[speaker.id] = speaker.displayName
               return acc
             }, {})}

--- a/packages/site/src/routes/[dictionaryId]/entries/AddImage.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/AddImage.svelte
@@ -79,6 +79,7 @@
     {#await import('$lib/components/image/UploadImage.svelte') then { default: UploadImage }}
       <UploadImage
         {file}
+        user={$user}
         fileLocationPrefix="{dictionaryId}/images/{entryId}_"
         on:uploaded={({detail: {fb_storage_path, specifiable_image_url}}) => saveImage(fb_storage_path, specifiable_image_url)} />
     {/await}

--- a/packages/site/src/routes/[dictionaryId]/settings/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/settings/+page.svelte
@@ -125,6 +125,7 @@
             <UploadImage
               {file}
               fileLocationPrefix={`${$dictionary.id}/featured_images/`}
+              user={$user}
               on:uploaded={async ({detail: {fb_storage_path, specifiable_image_url}}) => await updateDictionary({
                 featuredImage: {
                   fb_storage_path,


### PR DESCRIPTION
Change to dictionary and user stores import from page data broke media uploads because of a timing issue. The upload started before the value of those two were subscribed to.