### PR TITLE
display speaker names instead of speaker ids in table view

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/entries/table/Cell.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/Cell.svelte
@@ -20,6 +20,7 @@
 
   $: i18nKey = `entry_field.${column.field}` as i18nEntryFieldKey
   $: sense = entry.senses?.[0] || {}
+  $: ({ speakers } = $page.data)
 
   function updateEntry(data: ActualDatabaseEntry) {
     dbOperations.updateEntry({ data: data as GoalDatabaseEntry, entryId: entry.id })
@@ -49,7 +50,7 @@
       <!-- </div> -->
     {/if}
   {:else if column.field === 'speaker'}
-    <SelectSpeakerCell {can_edit} {entry} />
+    <SelectSpeakerCell speakers={$speakers} {can_edit} {entry} />
   {:else if column.field === 'parts_of_speech'}
     <EntryPartOfSpeech
       {can_edit}

--- a/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
@@ -4,8 +4,15 @@
   export let entry: ExpandedEntry
   export let can_edit = false
   export let speakers: ISpeaker[]
+  let displayed_speaker_name: string
 
-  $: first_sound_file = entry.sound_files?.[0]
+  $: first_sound_file = entry?.sound_files?.[0]
+  $: if (first_sound_file.speaker_ids) {
+    displayed_speaker_name = speakers.find(speaker => speaker.uid === first_sound_file.speaker_ids?.[0])?.displayName
+    if (!displayed_speaker_name) {
+      console.error(`Missing speaker ID: ${first_sound_file.speaker_ids?.[0]}`)
+    }
+  }
 </script>
 
 <div
@@ -25,7 +32,7 @@
   }}>
   {#if first_sound_file}
     {#if first_sound_file.speaker_ids?.length}
-      {speakers.find(speaker => speaker.uid === first_sound_file.speaker_ids[0]).displayName}
+      {displayed_speaker_name || ''}
     {:else}
       {first_sound_file.speakerName || ''}
     {/if}

--- a/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
@@ -12,6 +12,8 @@
     if (!displayed_speaker_name) {
       console.error(`Missing speaker ID: ${first_sound_file.speaker_ids[0]}`)
     }
+  } else {
+    displayed_speaker_name = first_sound_file.speakerName
   }
 </script>
 
@@ -30,12 +32,6 @@
       }
     }
   }}>
-  {#if first_sound_file}
-    {#if first_sound_file.speaker_ids?.length}
-      {displayed_speaker_name || ''}
-    {:else}
-      {first_sound_file.speakerName || ''}
-    {/if}
-  {/if}
+  {displayed_speaker_name || ''}
   &nbsp;
 </div>

--- a/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import type { ExpandedEntry } from '@living-dictionaries/types';
-  export let entry: ExpandedEntry;
-  export let can_edit = false;
+  import type { ExpandedEntry, ISpeaker } from '@living-dictionaries/types'
 
-  $: first_sound_file = entry.sound_files?.[0];
+  export let entry: ExpandedEntry
+  export let can_edit = false
+  export let speakers: ISpeaker[]
+
+  $: first_sound_file = entry.sound_files?.[0]
 </script>
 
 <div
@@ -14,16 +16,16 @@
     if (can_edit) {
       if (first_sound_file?.speaker_ids?.length) {
         alert(
-          'Please edit the speaker by from the edit audio modal accessed by clicking on the ear.'
-        );
+          'Please edit the speaker by from the edit audio modal accessed by clicking on the ear.',
+        )
       } else {
-        alert('Edit speaker feature is still in progress');
+        alert('Edit speaker feature is still in progress')
       }
     }
   }}>
   {#if first_sound_file}
     {#if first_sound_file.speaker_ids?.length}
-      {first_sound_file.speaker_ids[0]}
+      {speakers.find(speaker => speaker.uid === first_sound_file.speaker_ids[0]).displayName}
     {:else}
       {first_sound_file.speakerName || ''}
     {/if}

--- a/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.svelte
@@ -7,10 +7,10 @@
   let displayed_speaker_name: string
 
   $: first_sound_file = entry?.sound_files?.[0]
-  $: if (first_sound_file.speaker_ids) {
-    displayed_speaker_name = speakers.find(speaker => speaker.uid === first_sound_file.speaker_ids?.[0])?.displayName
+  $: if (first_sound_file.speaker_ids?.length) {
+    displayed_speaker_name = speakers.find(speaker => speaker.uid === first_sound_file.speaker_ids[0])?.displayName
     if (!displayed_speaker_name) {
-      console.error(`Missing speaker ID: ${first_sound_file.speaker_ids?.[0]}`)
+      console.error(`Missing speaker ID: ${first_sound_file.speaker_ids[0]}`)
     }
   }
 </script>

--- a/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.variants.ts
+++ b/packages/site/src/routes/[dictionaryId]/entries/table/cells/SelectSpeakerCell.variants.ts
@@ -1,0 +1,65 @@
+import type { Variant, VariantMeta } from 'kitbook'
+import type Component from './SelectSpeakerCell.svelte'
+
+export const shared_meta: VariantMeta = {
+  viewports: [
+    { width: 160, height: 70 },
+  ],
+}
+
+const shared = {
+  speakers: [
+    {
+      displayName: 'Anatoli',
+      uid: '123',
+    },
+  ],
+} satisfies Partial<Variant<Component>>
+
+export const Normal: Variant<Component> = {
+  ...shared,
+  entry: {
+    lexeme: 'test',
+    sound_files: [
+      { fb_storage_path: '', storage_url: '', speaker_ids: ['123'],
+      },
+    ],
+  },
+  can_edit: false,
+}
+
+export const Missing_Id: Variant<Component> = {
+  ...shared,
+  entry: {
+    lexeme: 'test',
+    sound_files: [
+      { fb_storage_path: '', storage_url: '', speaker_ids: ['456'],
+      },
+    ],
+  },
+  can_edit: false,
+}
+
+export const Speaker_Name: Variant<Component> = {
+  ...shared,
+  entry: {
+    lexeme: 'test',
+    sound_files: [
+      { fb_storage_path: '', storage_url: '', speakerName: 'María',
+      },
+    ],
+  },
+  can_edit: false,
+}
+
+export const Speaker_Name_And_Speaker_Id: Variant<Component> = {
+  ...shared,
+  entry: {
+    lexeme: 'test',
+    sound_files: [
+      { fb_storage_path: '', storage_url: '', speakerName: 'Diego', speaker_ids: ['123'],
+      },
+    ],
+  },
+  can_edit: false,
+}


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #181 

#### Summarize what changed in this PR (for developers)


#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [x] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [x] Classes (a Svelte Component is a Class)
    - [x] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [x] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed