### PR TITLE
add norobots option to non public dictionaries

### DIFF
--- a/packages/site/src/routes/[dictionaryId]/about/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/about/+page.svelte
@@ -52,6 +52,7 @@
 </div>
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('header.about')}
   dictionaryName={dictionary.name}
   description="Learn about the background and creation of this Living Dictionary."

--- a/packages/site/src/routes/[dictionaryId]/contributors/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/contributors/+page.svelte
@@ -204,6 +204,7 @@
 <div class="mb-12" />
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('dictionary.contributors')}
   dictionaryName={dictionary.name}
   description="Learn about the people who are building and managing this Living Dictionary."

--- a/packages/site/src/routes/[dictionaryId]/entries/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entries/+page.svelte
@@ -102,6 +102,7 @@
 </ShowHide>
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   admin={$admin > 0}
   title="Entries"
   dictionaryName={dictionary.name}

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/+page.svelte
@@ -80,6 +80,7 @@
   {dbOperations} />
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   imageTitle={entry.main.lexeme.default}
   imageDescription={seo_description({ entry, dialects: $dialects, gloss_languages: dictionary.gloss_languages, t: $page.data.t })}
   dictionaryName={dictionary.name}

--- a/packages/site/src/routes/[dictionaryId]/export/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/export/+page.svelte
@@ -137,6 +137,7 @@
 {/if}
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('misc.export')}
   dictionaryName={dictionary.name}
   description="Dictionary managers can easily export their Living Dictionary\'s text data as a .CSV spreadsheet as well as export their images and audio files in convenient ZIP folders."

--- a/packages/site/src/routes/[dictionaryId]/grammar/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/grammar/+page.svelte
@@ -50,6 +50,7 @@
 </div>
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('dictionary.grammar')}
   dictionaryName={dictionary.name}
   description="Learn about the grammar of the language in this Living Dictionary."

--- a/packages/site/src/routes/[dictionaryId]/settings/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/settings/+page.svelte
@@ -140,6 +140,7 @@
 </div>
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('misc.settings')}
   dictionaryName={dictionary.name}
   description="Under Settings, dictionary managers can edit the dictionary\'s parameters such as its name, ISO 639-3 Code, Glottocode, translation languages, alternate names, geo-coordinates, and other information. They can also toggle on or off the ability to make the dictionary public, and the ability to make the dictionary printable to viewers."

--- a/packages/site/src/routes/[dictionaryId]/synopsis/+page.svelte
+++ b/packages/site/src/routes/[dictionaryId]/synopsis/+page.svelte
@@ -44,6 +44,7 @@
 </div>
 
 <SeoMetaTags
+  norobots={!dictionary.public}
   title={$page.data.t('synopsis.name')}
   dictionaryName={name}
   description="View the parameters of this Living Dictionary, such as its name, ISO 639-3 Code, Glottocode, the translation languages present within this dictionary, the alternate names for this language, the geo-coordinates for this language, and more."


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)


#### Summarize what changed in this PR (for developers)

I added norobots prop for all non public dictionaries in all dictionary pages: list, table, export, grammar, etc...