### PR TITLE
avoid splitting speaker strings

### DIFF
--- a/packages/site/src/lib/search/multilingual-tokenizer.ts
+++ b/packages/site/src/lib/search/multilingual-tokenizer.ts
@@ -7,7 +7,7 @@ function normalizeToken(this: DefaultTokenizer, prop: string, token: string): st
 
 // _withCache is true for user searches and false when indexing
 export function tokenize(input: string, language?: string, prop = '', _withCache = true): string[] {
-  if (typeof input !== 'string') {
+  if (typeof input !== 'string' || prop === '_speakers') {
     return [input]
   }
 


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
closes #591 

#### Summarize what changed in this PR (for developers)
I am preventing Orama from splitting the string when it comes to speakers.