### PR TITLE
Multiple sentences per entry

### DIFF
--- a/packages/site/.env.development
+++ b/packages/site/.env.development
@@ -1,7 +1,7 @@
 # To develop against a local Supabase instance, make sure you have Docker installed and then run `pnpx supabase start` before running `pnpm dev`.
 PUBLIC_SUPABASE_API_URL=http://127.0.0.1:54321
-PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+PUBLIC_SUPABASE_ANON_KEY=sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH
+SUPABASE_SERVICE_ROLE_KEY=sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz
 PUBLIC_STUDIO_URL=http://127.0.0.1:54323 # convenience link
 PUBLIC_INBUCKET_URL=http://127.0.0.1:54324 # convenience link
 

--- a/packages/site/src/lib/constants.ts
+++ b/packages/site/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar']
+export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar', 'sugtstun-test', 'yaruro-colombiano']
 
 export enum ResponseCodes {
   OK = 200,

--- a/packages/site/src/lib/constants.ts
+++ b/packages/site/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar']
+export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar', 'sugtstun-test']
 
 export enum ResponseCodes {
   OK = 200,

--- a/packages/site/src/lib/constants.ts
+++ b/packages/site/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar', 'sugtstun-test', 'yaruro-colombiano']
+export const DICTIONARIES_WITH_VARIANTS = ['babanki', 'torwali', 'ksingmul', 'tutelo-saponi', 'tseltal', 'namtrik-de-totoro', 'werikyana', 'woleaia', 'guwar', 'sugtstun-test', 'yaruro-colombiano', 'rusitene']
 
 export enum ResponseCodes {
   OK = 200,

--- a/packages/site/src/lib/dbOperations.ts
+++ b/packages/site/src/lib/dbOperations.ts
@@ -1,4 +1,4 @@
-import { assign_dialect, assign_speaker, assign_tag, insert_audio, insert_dialect, insert_entry, insert_photo, insert_sense, insert_sentence, insert_speaker, insert_tag, insert_video, update_audio, update_entry, update_photo, update_sense, update_sentence, update_video } from '$lib/supabase/operations'
+import { assign_dialect, assign_speaker, assign_tag, delete_sentence, insert_audio, insert_dialect, insert_entry, insert_photo, insert_sense, insert_sentence, insert_speaker, insert_tag, insert_video, update_audio, update_entry, update_photo, update_sense, update_sentence, update_video } from '$lib/supabase/operations'
 import { addAudio, addImage, uploadVideo } from '$lib/helpers/media'
 
 export const dbOperations = {
@@ -10,6 +10,7 @@ export const dbOperations = {
 
   insert_sentence,
   update_sentence,
+  delete_sentence,
 
   insert_audio,
   update_audio,

--- a/packages/site/src/lib/i18n/locales/en.json
+++ b/packages/site/src/lib/i18n/locales/en.json
@@ -412,5 +412,9 @@
   },
   "image": {
     "photographer": "Photographer"
+  },
+  "sentence": {
+    "add": "Add sentence",
+    "delete": "Delete sentence"
   }
 }

--- a/packages/site/src/lib/mocks/db.ts
+++ b/packages/site/src/lib/mocks/db.ts
@@ -44,6 +44,7 @@ export const logDbOperations: DbOperations = {
   update_sense: log_args,
   insert_sentence: log_args,
   update_sentence: log_args,
+  delete_sentence: log_args,
   insert_audio: log_args,
   update_audio: log_args,
   insert_speaker: log_args,

--- a/packages/site/src/lib/search/augment-entry-for-search.ts
+++ b/packages/site/src/lib/search/augment-entry-for-search.ts
@@ -21,7 +21,7 @@ export function augment_entry_for_search(entry: EntryData) {
   const _glosses = senses.flatMap(sense => Object.values(sense.glosses || {}).filter(Boolean))
 
   const sentences = senses.flatMap(sense =>
-    sense.sentences?.flatMap(({ text }) => Object.values(text).filter(Boolean)) || [],
+    sense.sentences?.flatMap(s => (s.text ? Object.values(s.text).filter(Boolean) : [])) || [],
   )
   const plural_forms = senses.flatMap(sense => Object.values(sense.plural_form || {}).filter(Boolean))
 

--- a/packages/site/src/lib/search/entry.worker.ts
+++ b/packages/site/src/lib/search/entry.worker.ts
@@ -265,6 +265,13 @@ const operations = {
     const entry_id = senses[sense_id]?.entry_id
     await process_and_update_entry(entries[entry_id])
   },
+  delete_sentence: async (sentence_id: string) => {
+    const sense_id = sentence_id_to_sense_ids[sentence_id]?.[0]
+    delete sentences[sentence_id]
+    sense_id_to_sentences[sense_id] = sense_id_to_sentences[sense_id]?.filter(s => s.id !== sentence_id) || []
+    const entry_id = senses[sense_id]?.entry_id
+    await process_and_update_entry(entries[entry_id])
+  },
   insert_tag: async (tag: TablesInsert<'tags'>) => {
     tags[tag.id] = tag as Tables<'tags'>
     await set_tags(Object.values(tags))

--- a/packages/site/src/lib/search/entry.worker.ts
+++ b/packages/site/src/lib/search/entry.worker.ts
@@ -263,14 +263,14 @@ const operations = {
       })
     }
     const entry_id = senses[sense_id]?.entry_id
-    await process_and_update_entry(entries[entry_id])
+    if (entry_id && entries[entry_id]) await process_and_update_entry(entries[entry_id])
   },
   delete_sentence: async (sentence_id: string) => {
     const sense_id = sentence_id_to_sense_ids[sentence_id]?.[0]
     delete sentences[sentence_id]
     sense_id_to_sentences[sense_id] = sense_id_to_sentences[sense_id]?.filter(s => s.id !== sentence_id) || []
     const entry_id = senses[sense_id]?.entry_id
-    await process_and_update_entry(entries[entry_id])
+    if (entry_id && entries[entry_id]) await process_and_update_entry(entries[entry_id])
   },
   insert_tag: async (tag: TablesInsert<'tags'>) => {
     tags[tag.id] = tag as Tables<'tags'>

--- a/packages/site/src/lib/supabase/operations.ts
+++ b/packages/site/src/lib/supabase/operations.ts
@@ -114,8 +114,6 @@ export async function insert_sentence({ sentence, sense_id }: {
       dictionary_id,
       ...sentence,
     }
-    await api.insert_sentence(new_sentence, sense_id)
-
     const { data, error } = await supabase.from('sentences').insert(new_sentence).select().single()
     if (error)
       throw new Error(error.message)
@@ -127,7 +125,14 @@ export async function insert_sentence({ sentence, sense_id }: {
     })
     if (sense_in_sentence_error)
       throw new Error(sense_in_sentence_error.message)
-    return data
+
+    try {
+      await api.insert_sentence(new_sentence, sense_id)
+    } catch (worker_err) {
+      console.error('insert_sentence: worker error', worker_err)
+    }
+
+return data
   } catch (err) {
     alert(err)
     console.error(err)
@@ -137,10 +142,14 @@ export async function insert_sentence({ sentence, sense_id }: {
 export async function update_sentence(sentence: TablesUpdate<'sentences'>) {
   try {
     const { api, supabase } = await get_pieces()
-    await api.update_sentence(sentence)
     const { data, error } = await supabase.from('sentences').update(sentence).eq('id', sentence.id).select().single()
     if (error)
       throw new Error(error.message)
+    try {
+      await api.update_sentence(sentence)
+    } catch (worker_err) {
+      console.error('update_sentence: worker error', worker_err)
+    }
     return data
   } catch (err) {
     alert(err)
@@ -153,10 +162,14 @@ export async function delete_sentence(sentence_id: string) {
     if (!confirm('Are you sure you want to delete this sentence?')) return
 
     const { api, supabase } = await get_pieces()
-    await api.delete_sentence(sentence_id)
     const { error } = await supabase.from('sentences').update({ deleted: new Date().toISOString() }).eq('id', sentence_id)
     if (error)
       throw new Error(error.message)
+    try {
+      await api.delete_sentence(sentence_id)
+    } catch (worker_err) {
+      console.error('delete_sentence: worker error', worker_err)
+    }
   } catch (err) {
     alert(err)
     console.error(err)

--- a/packages/site/src/lib/supabase/operations.ts
+++ b/packages/site/src/lib/supabase/operations.ts
@@ -148,6 +148,21 @@ export async function update_sentence(sentence: TablesUpdate<'sentences'>) {
   }
 }
 
+export async function delete_sentence(sentence_id: string) {
+  try {
+    if (!confirm('Are you sure you want to delete this sentence?')) return
+
+    const { api, supabase } = await get_pieces()
+    await api.delete_sentence(sentence_id)
+    const { error } = await supabase.from('sentences').update({ deleted: new Date().toISOString() }).eq('id', sentence_id)
+    if (error)
+      throw new Error(error.message)
+  } catch (err) {
+    alert(err)
+    console.error(err)
+  }
+}
+
 export async function insert_audio({
   storage_path,
   entry_id,

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/EntrySentence.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/EntrySentence.svelte
@@ -14,9 +14,19 @@
 </script>
 
 <div class:order-2={!sentence.id} class="flex flex-col">
+  {#if can_edit && sentence.id}
+    <button
+      type="button"
+      class="self-end text-gray-400 hover:text-red-500"
+      title={$page.data.t('sentence.delete')}
+      on:click={() => dbOperations.delete_sentence(sentence.id)}>
+      <span class="i-system-uicons-trash text-xl" />
+    </button>
+  {/if}
+
   {#each writing_systems as orthography}
     <EntryField
-      value={sentence.text[orthography]}
+      value={sentence.text?.[orthography]}
       field="example_sentence"
       {can_edit}
       display={$page.data.t('entry_field.example_sentence')}
@@ -46,7 +56,7 @@
         on_update={(new_value) => {
           dbOperations.update_sentence({
             translation: {
-              ...sentence.translation,
+              ...(sentence.translation || {}),
               [bcp]: new_value,
             },
             id: sentence.id,

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/Sense.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/Sense.svelte
@@ -95,7 +95,7 @@
   <EntrySentence sentence={{ text: {}, id: null, translation: null }} {can_edit} sense_id={sense.id} glossingLanguages={glossingLanguages} />
 {/if}
 
-{#if can_edit}
+{#if can_edit && sense.sentences?.length}
   <button
     type="button"
     class="text-start p-2 mb-2 rounded hover:bg-gray-100 text-gray-600"

--- a/packages/site/src/routes/[dictionaryId]/entry/[entryId]/Sense.svelte
+++ b/packages/site/src/routes/[dictionaryId]/entry/[entryId]/Sense.svelte
@@ -95,6 +95,15 @@
   <EntrySentence sentence={{ text: {}, id: null, translation: null }} {can_edit} sense_id={sense.id} glossingLanguages={glossingLanguages} />
 {/if}
 
+{#if can_edit}
+  <button
+    type="button"
+    class="text-start p-2 mb-2 rounded hover:bg-gray-100 text-gray-600"
+    on:click={() => dbOperations.insert_sentence({ sentence: {}, sense_id: sense.id })}>
+    <span class="i-system-uicons-versions text-xl" /> {$page.data.t('sentence.add')}
+  </button>
+{/if}
+
 <EntryField
   value={sense.plural_form?.default}
   field="plural_form"

--- a/packages/site/src/routes/[dictionaryId]/export/getRows.ts
+++ b/packages/site/src/routes/[dictionaryId]/export/getRows.ts
@@ -27,7 +27,7 @@ export function get_glosses(glosses: MultiString, metadata: ExportMetaData) {
   if (glosses) {
     Object.entries(glosses).forEach(([bcp, value]) => {
       formatted_data[`${count_sense(sense_index)}${bcp}_gloss`] = position === 'header'
-        ? `${get_readable_sense(sense_index)}${glossingLanguages[bcp].vernacularName || bcp} Gloss`
+        ? `${get_readable_sense(sense_index)}${glossingLanguages[bcp]?.vernacularName || bcp} Gloss`
         : value
     })
   }
@@ -77,7 +77,7 @@ export function get_example_sentence(
   if (sentence?.translation) {
     Object.keys(sentence?.translation).forEach((bcp) => {
       formatted_data[`${count_sense(sense_index)}${bcp}_exampleSentence`] = position === 'header'
-        ? `${get_readable_sense(sense_index)}Example sentence in ${glossingLanguages[bcp].vernacularName || bcp}`
+        ? `${get_readable_sense(sense_index)}Example sentence in ${glossingLanguages[bcp]?.vernacularName || bcp}`
         : sentence.translation?.[bcp]
     })
   }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,6 +1,6 @@
--- INSERT INTO auth.users ("aud", "email", "id", "instance_id", "role", "confirmation_token", "recovery_token", "email_change_token_new", "email_change") VALUES
--- ('authenticated', 'jacob@livingtongues.org', 'de2d3715-6337-45a3-a81a-d82c3210b2a7', '00000000-0000-0000-0000-000000000000', 'authenticated', '', '', '', ''),
--- ('authenticated', 'diego@livingtongues.org', 'be43b1dd-6c64-494d-b5da-10d70c384433', '00000000-0000-0000-0000-000000000000', 'authenticated', '', '', '', '');
+-- INSERT INTO auth.users (id, email, instance_id, aud, role) VALUES
+-- ('de2d3715-6337-45a3-a81a-d82c3210b2a7', 'jacob@livingtongues.org', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated'),
+-- ('be43b1dd-6c64-494d-b5da-10d70c384433', 'diego@livingtongues.org', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated');
 
--- INSERT INTO "public"."dictionaries" ("id", "name", "gloss_languages", "created_at", "created_by", "updated_at", "updated_by") VALUES
--- ('test', 'Test Dictionary', '{"en"}', '2024-03-18 14:16:22.367188+00', 'de2d3715-6337-45a3-a81a-d82c3210b2a7', '2024-03-18 14:16:22.367188+00', 'de2d3715-6337-45a3-a81a-d82c3210b2a7');
+-- INSERT INTO dictionaries (id, name, gloss_languages, created_at, created_by, updated_at, updated_by, url) VALUES
+-- ('test', 'Test Dictionary', '{"en"}', '2024-03-18 14:16:22.367188+00', 'de2d3715-6337-45a3-a81a-d82c3210b2a7', '2024-03-18 14:16:22.367188+00', 'de2d3715-6337-45a3-a81a-d82c3210b2a7', 'test');


### PR DESCRIPTION
#### Relevant Issue
(prepend "closes" if issue will be closed by PR)
Enables multiple example sentences per dictionary entry (per sense). Previously, only 0 or 1 sentence was supported per sense. Now users can add, edit, and delete multiple sentences for each sense.


#### Summarize what changed in this PR (for developers)
- Added delete_sentence backend operation with null-safety fixes for Orama search index updates
- Added delete button (trash icon) to each sentence in UI
- Updated "Add sentence" button to only appear when at least one sentence already exists
- Fixed database trigger typo (sense_sentences → senses_in_sentences)


#### How can the changes be tested? 
Please also provide applicable links using relative paths from root (e.g. `/apatani/entries`) and reviewers can just add that onto preview urls or localhost.


#### Checklist before marking ready to merge
Please keep it in draft mode until these are completed:
- [ ] Equal time was spent cleaning the code as writing it (Boy Scout Rule)
  - [ ] Functions
    - [ ] Functions that don't belong in Svelte components are extracted out into `.ts` files
    - [ ] Functions are short and well named
    - [ ] Concise tests are written for all functions
  - [ ] Classes (a Svelte Component is a Class)
    - [ ] Svelte components are broken down into smaller components so that each component is responsible for one thing (Single Responsibility Principle)
    - [ ] Stories/variants are written to describe use cases
  - [ ] Comments are only included when absolutely necessary information that cannot be explained in code is needed