### PR TITLE
Use node:path sep for cross-platform dev-media path traversal check

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,11 @@
+// Suppress the prepare script for eslint-plugin-svelte-stylistic (git-hosted dep).
+// Its `simple-git-hooks` prepare script requires a full devDependency install that
+// fails on Windows, and the package ships prebuilt dist/ — nothing needs compiling.
+function readPackage(pkg, _context) {
+  if (pkg.name === 'eslint-plugin-svelte-stylistic') {
+    delete pkg.scripts.prepare
+  }
+  return pkg
+}
+
+module.exports = { hooks: { readPackage } }

--- a/site/src/routes/api/dev-media/[...path]/+server.ts
+++ b/site/src/routes/api/dev-media/[...path]/+server.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 import { error, redirect } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import { R2_MEDIA_DOMAIN, ResponseCodes } from '$lib/constants'
@@ -20,7 +20,7 @@ import { is_r2_media_path } from '$lib/utils/media-path'
 function safe_join(path: string): string {
   const root = dev_media_dir()
   const full = join(root, path)
-  if (!full.startsWith(`${root}/`) && full !== root)
+  if (!full.startsWith(`${root}${sep}`) && full !== root)
     error(ResponseCodes.BAD_REQUEST, 'Invalid path')
   return full
 }


### PR DESCRIPTION
The safe_join path traversal guard used a hardcoded forward slash, which fails on Windows where join() produces backslash-separated paths. Using sep from node:path ensures the check matches the platform separator on both Linux and Windows.

Also add .pnpmfile.cjs to suppress the eslint-plugin-svelte-stylistic prepare script (simple-git-hooks), which forces a 500+ package devDependency install that fails on Windows. The plugin ships prebuilt dist/ — no build needed.